### PR TITLE
(CTH-25) - First cut of the BaseClient class.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,6 @@ INCLUDE_DIRECTORIES("${MAINFOLDER}/include")
 #
 # Dependency Packages
 #
-
 FIND_PACKAGE(Boost 1.55 REQUIRED COMPONENTS program_options system random)
 if (NOT Boost_FOUND)
     MESSAGE (FATAL_ERROR "Boost is required. Please install it before using ${APPLICATION_NAME}")

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -1,6 +1,7 @@
 #include "client.h"
 
 #include <iostream>
+#include <chrono>
 
 // NB: (from websocketpp wiki) "Per the websocket spec, a client can
 // only have one connection in the connecting state at a time."
@@ -23,10 +24,11 @@ BaseClient::BaseClient() {
     client_.set_fail_handler(bind(&BaseClient::onFail_, this, ::_1));
     client_.set_message_handler(bind(&BaseClient::onMessage_, this, ::_1, ::_2));
 
-    connection_thread_.reset(new std::thread(&Client_Configuration::run, &client_));
+    connection_thread_.reset(
+        new std::thread(&Client_Configuration::run, &client_));
 }
 
-Connection_ID BaseClient::connect(std::string url) {
+Connection_Handle BaseClient::connect(std::string url) {
     // TODO(ale): url validation
     // TODO(ale): use the exception-based call
     websocketpp::lib::error_code ec;
@@ -38,29 +40,30 @@ Connection_ID BaseClient::connect(std::string url) {
                                  + ec.message() };
     }
 
-    websocketpp::connection_hdl hdl { connection_p->get_handle() };
+    ConnectionMetadata connection_metadata {};
+    Connection_Handle hdl { connection_p->get_handle() };
     client_.connect(connection_p);
-
-    Connection_ID id = getNewConnectionID();
-    connection_handlers_.insert(Connection_Handler_Pair { id, hdl });
-    return id;
+    metadata_of_connections_.insert(
+        std::pair<Connection_Handle, ConnectionMetadata> {
+            hdl, connection_metadata });
+    return hdl;
 }
 
 // TODO(ale): is it safe to upgrade to pointer and get state?
 // In alternative, keep the state inside connection_metadata...
 
-websocketpp::session::state::value BaseClient::getStateOf(
-        Connection_ID connection_id) {
-    websocketpp::connection_hdl hdl = getConnectionHandler(connection_id);
+Connection_State BaseClient::getStateOf(Connection_Handle hdl) {
+    checkConnectionHandle(hdl);
     // Upgrade to the pointer
     Client_Configuration::connection_ptr con = client_.get_con_from_hdl(hdl);
     return con->get_state();
 }
 
 // TODO(ale): do we need a message class?; handle binary payload
+// TODO(ale): use ConnectionMetadata state to validate
 
-void BaseClient::send(Connection_ID connection_id, std::string message) {
-    websocketpp::connection_hdl hdl = getConnectionHandler(connection_id);
+void BaseClient::send(Connection_Handle hdl, std::string message) {
+    checkConnectionHandle(hdl);
     websocketpp::lib::error_code ec;
     client_.send(hdl, message, websocketpp::frame::opcode::text, ec);
     if (ec) {
@@ -68,37 +71,97 @@ void BaseClient::send(Connection_ID connection_id, std::string message) {
     }
 }
 
-void BaseClient::closeConnection(Connection_ID connection_id) {
-    websocketpp::connection_hdl hdl = getConnectionHandler(connection_id);
+void BaseClient::sendWhenEstablished(Connection_Handle hdl, std::string msg,
+                                     int num_intervals, int interval_duration) {
+    Connection_State current_state { getStateOf(hdl) };
+
+    if (current_state == Connection_State_Values::open) {
+        send(hdl, msg);
+    } else if (current_state != Connection_State_Values::connecting) {
+        int interval_idx { 0 };
+        while (interval_idx < num_intervals) {
+            if (getStateOf(hdl) == Connection_State_Values::open) {
+                send(hdl, msg);
+                return;
+            }
+            interval_idx++;
+            std::this_thread::sleep_for(
+                std::chrono::milliseconds(interval_duration));
+        }
+        throw message_error { "Send timeout" };
+    } else {
+        // TODO(ale): identify connection
+        throw message_error { "Invalid connection state" };
+    }
+}
+
+
+void BaseClient::closeConnection(Connection_Handle hdl, Close_Code code,
+                                 Message reason) {
+    checkConnectionHandle(hdl);
     websocketpp::lib::error_code ec;
-    std::cout << "### About to close connection " << connection_id << std::endl;
-    client_.close(hdl, websocketpp::close::status::normal, "", ec);
+    // TODO(ale): connection id from ConnectionMetadata
+    std::cout << "### About to close connection " << std::endl;
+    client_.close(hdl, code, reason, ec);
     if (ec) {
-        throw message_error { "Failed to close connetion " + connection_id
-                              + ": " + ec.message() };
+        throw message_error { "Failed to close connetion: " + ec.message() };
     }
 }
 
 void BaseClient::closeAllConnections() {
-    for (auto handler_iter = connection_handlers_.begin();
-        handler_iter != connection_handlers_.end(); handler_iter++) {
-        closeConnection(handler_iter->first);
+    for (auto metadata_iter = metadata_of_connections_.begin();
+         metadata_iter != metadata_of_connections_.end(); metadata_iter++) {
+        closeConnection(metadata_iter->first);
     }
-    connection_handlers_ = Connection_Handlers {};
+    metadata_of_connections_.clear();
+}
+
+//
+// Event loop callbacks
+//
+
+// TODO(ale): log message at the right log level for all callbacks
+// TODO(ale): callbacks should set the ConnectionMetadata state
+
+void BaseClient::onOpen_(Connection_Handle hdl) {}
+
+void BaseClient::onClose_(Connection_Handle hdl) {}
+
+void BaseClient::onFail_(Connection_Handle hdl) {}
+
+Context_Ptr BaseClient::onTlsInit_(Connection_Handle hdl) {
+    Context_Ptr ctx {
+        new boost::asio::ssl::context(boost::asio::ssl::context::tlsv1) };
+
+    try {
+        ctx->set_options(boost::asio::ssl::context::default_workarounds |
+                         boost::asio::ssl::context::no_sslv2 |
+                         boost::asio::ssl::context::single_dh_use);
+    } catch (std::exception& e) {
+        // TODO(ale): this is what the the debug_client does and it
+        // seems to work, nonetheless check if we need to raise here
+        std::cout << "### ERROR (tls): " << e.what() << std::endl;
+    }
+    return ctx;
+}
+
+void BaseClient::onMessage_(Connection_Handle hdl,
+                            Client_Configuration::message_ptr msg) {
+    std::cout << "### Got a MESSAGE!!! " << msg->get_payload() << std::endl;
 }
 
 //
 // BaseClient private interface
 //
 
-websocketpp::connection_hdl BaseClient::getConnectionHandler(
-        Connection_ID connection_id) {
-    Connection_Handlers::iterator handler_iter =
-        connection_handlers_.find(connection_id);
-    if (handler_iter == connection_handlers_.end()) {
-        throw unknown_connection { connection_id };
+void BaseClient::checkConnectionHandle(Connection_Handle hdl) {
+    std::map<Connection_Handle, ConnectionMetadata,
+             std::owner_less<Connection_Handle>>::iterator metadata_iter
+                = metadata_of_connections_.find(hdl);
+    if (metadata_iter == std::end(metadata_of_connections_)) {
+        // TODO(ale): get some id from ConnectionMetadata
+        throw unknown_connection {};
     }
-    return handler_iter->second;
 }
 
 void BaseClient::shutdown() {

--- a/src/common/uuid.h
+++ b/src/common/uuid.h
@@ -10,6 +10,9 @@
 namespace Cthun {
 namespace Common {
 
+// TODO(ale): this is currently unused; remove if still unused after
+// implementing ConnectionMetadata.
+
 typedef std::string UUID;
 
 static UUID getUUID() __attribute__((unused));

--- a/src/connection_metadata.cpp
+++ b/src/connection_metadata.cpp
@@ -2,10 +2,11 @@
 #include <iostream>
 
 namespace Cthun {
+namespace Client {
 
-ConnectionMetadata::ConnectionMetadata(std::string url)
-    : url_ { url } {
-    std::cout << "### Inside ConnectionMetadata init! Url = " << url_ << "\n";
-}
+// TODO(ale): todo
 
+ConnectionMetadata::ConnectionMetadata() {}
+
+}  // namespace Client
 }  // namespace Cthun

--- a/src/connection_metadata.h
+++ b/src/connection_metadata.h
@@ -1,19 +1,18 @@
 #ifndef CTHUN_CLIENT_SRC_CONNECTION_METADATA_H_
 #define CTHUN_CLIENT_SRC_CONNECTION_METADATA_H_
 
-#include <string>
-
 namespace Cthun {
+namespace Client {
+
+// TODO(ale): connection state attribute, to be set by event callbacks;
+// will require lock - must check overhead impact
 
 class ConnectionMetadata {
   public:
-    ConnectionMetadata() = delete;
-    explicit ConnectionMetadata(std::string url);
-
-  private:
-    std::string url_;
+    ConnectionMetadata();
 };
 
+}  // namespace Client
 }  // namespace Cthun
 
 #endif  // CTHUN_CLIENT_SRC_CONNECTION_METADATA_H_

--- a/src/test_client.cpp
+++ b/src/test_client.cpp
@@ -53,24 +53,5 @@ void TestClient::onFail_(websocketpp::connection_hdl hdl) {
     std::cout << "### Triggered onFail_()\n";
 }
 
-Context_Ptr TestClient::onTlsInit_(websocketpp::connection_hdl hdl) {
-    Context_Ptr ctx {
-        new boost::asio::ssl::context(boost::asio::ssl::context::tlsv1) };
-
-    try {
-        ctx->set_options(boost::asio::ssl::context::default_workarounds |
-                         boost::asio::ssl::context::no_sslv2 |
-                         boost::asio::ssl::context::single_dh_use);
-    } catch (std::exception& e) {
-        std::cout << "### ERROR (tls): " << e.what() << std::endl;
-    }
-    return ctx;
-}
-
-void TestClient::onMessage_(websocketpp::connection_hdl hdl,
-                            Client_Configuration::message_ptr msg) {
-        std::cout << "### Got a MESSAGE!!! " << msg->get_payload() << std::endl;
-}
-
 }  // namespace Client
 }  // namespace Cthun

--- a/src/test_client.h
+++ b/src/test_client.h
@@ -17,20 +17,13 @@ class TestClient : public BaseClient {
     ~TestClient();
 
     /// Event loop open callback.
-    void onOpen_(websocketpp::connection_hdl hdl);
+    void onOpen_(Connection_Handle hdl);
 
     /// Event loop close callback.
-    void onClose_(websocketpp::connection_hdl hdl);
+    void onClose_(Connection_Handle hdl);
 
     /// Event loop failure callback.
-    void onFail_(websocketpp::connection_hdl hdl);
-
-    /// Event loop TLS init callback.
-    Context_Ptr onTlsInit_(websocketpp::connection_hdl hdl);
-
-    /// Event loop failure callback.
-    void onMessage_(websocketpp::connection_hdl hdl,
-                    Client_Configuration::message_ptr msg);
+    void onFail_(Connection_Handle hdl);
 
   private:
     std::vector<Message> & messages_;


### PR DESCRIPTION
Improving the WebSocket client wrapper class.

Avoid using UUIDs to identify a connection; use the websocketpp
connection handler instead.

Define event handlers in the base class.

New sendWhenEstablished() function, that waits for the connection being
established before attempting to send the given message.
