### PR TITLE
(maint) - Always include asio_client.hpp

### DIFF
--- a/src/client.h
+++ b/src/client.h
@@ -1,19 +1,19 @@
 #ifndef CTHUN_CLIENT_SRC_CLIENT_H_
 #define CTHUN_CLIENT_SRC_CLIENT_H_
 
+// Comment the CTHUN_CLIENT_SECURE_TRANSPORT def to not use TLS
+#define CTHUN_CLIENT_SECURE_TRANSPORT
+
 #include "common/uuid.h"
 #include "errors.h"
 #include "macros.h"
 
 #include <websocketpp/common/connection_hdl.hpp>
 #include <websocketpp/client.hpp>
-
-// Comment the CTHUN_CLIENT_SECURE_TRANSPORT def to not use TLS
-#define CTHUN_CLIENT_SECURE_TRANSPORT
-
-#ifdef CTHUN_CLIENT_SECURE_TRANSPORT
+// NB: we must include asio_client.hpp even if CTHUN_CLIENT_SECURE_TRANSPORT
+// is not defined in order to define Context_Ptr
 #include <websocketpp/config/asio_client.hpp>
-#else
+#ifndef CTHUN_CLIENT_SECURE_TRANSPORT
 #include <websocketpp/config/asio_no_tls_client.hpp>
 #endif  // CTHUN_CLIENT_SECURE_TRANSPORT
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,7 +27,6 @@ int runTestConnection(std::string url,
 
     std::vector<Client::Connection::Ptr> connections;
 
-
     for (auto i = 0; i < num_connections; i++) {
         try {
             // Create and configure a Connection


### PR DESCRIPTION
We need to include asio_client.hpp to define Context_Ptr, even in the no
TLS case.
