### PR TITLE
(CTH-26) - Configuring boost::log

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,8 @@ INCLUDE_DIRECTORIES("${MAINFOLDER}/include")
 #
 # Dependency Packages
 #
-FIND_PACKAGE(Boost 1.55 REQUIRED COMPONENTS program_options system random)
+FIND_PACKAGE(Boost 1.55 REQUIRED COMPONENTS program_options system random log
+             thread date_time regex)
 if (NOT Boost_FOUND)
     MESSAGE (FATAL_ERROR "Boost is required. Please install it before using ${APPLICATION_NAME}")
 endif ()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,9 @@
 # Set sources
 SET(SOURCES
-    connection.cpp
+    log/log.cpp
+    configuration.cpp
     endpoint.cpp
+    connection.cpp
     connection_manager.cpp
 )
 

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -1,0 +1,14 @@
+#include "configuration.h"
+
+LOG_DECLARE_NAMESPACE("client.configuration");
+
+namespace Cthun {
+namespace Client {
+
+void Configuration::initializeLogging(Log::log_level log_level,
+                                      std::ostream& log_stream) {
+    Log::configure_logging(log_level, log_stream);
+}
+
+}  // namespace Client
+}  // namespace Cthun

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -1,0 +1,26 @@
+#ifndef CTHUN_CLIENT_SRC_CONFIGURATION_H_
+#define CTHUN_CLIENT_SRC_CONFIGURATION_H_
+
+#include "log/log.h"
+
+#include <iostream>
+
+namespace Cthun {
+namespace Client {
+namespace Configuration {
+
+static const Log::log_level DEFAULT_LOG_LEVEL { Log::log_level::info };
+static std::ostream& DEFAULT_LOG_STREAM { std::cout };
+
+// TODO(ale): allow configuring log to file
+
+/// Configure the default logging.
+void initializeLogging(
+    Log::log_level log_level = DEFAULT_LOG_LEVEL,
+    std::ostream& log_stream = DEFAULT_LOG_STREAM);
+
+}  // namespace Configuration
+}  // namespace Client
+}  // namespace Cthun
+
+#endif  // CTHUN_CLIENT_SRC_CONFIGURATION_H_

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -1,8 +1,11 @@
 #include "connection.h"
 #include "common/uuid.h"
+#include "log/log.h"
 
 #include <string>
 #include <iostream>
+
+LOG_DECLARE_NAMESPACE("client.connection");
 
 namespace Cthun {
 namespace Client {
@@ -93,7 +96,7 @@ Close_Code Connection::getRemoteCloseCode() const {
 // TODO(ale): session validation; TLS
 
 void Connection::onOpen(Client_Type* client_ptr, Connection_Handle hdl) {
-    std::cout << "### triggered onOpen!\n";
+    LOG_DEBUG("triggered onOpen");
 
     state_ = Connection_State_Values::open;
     Client_Type::connection_ptr websocket_ptr { client_ptr->get_con_from_hdl(hdl) };
@@ -103,7 +106,7 @@ void Connection::onOpen(Client_Type* client_ptr, Connection_Handle hdl) {
 }
 
 void Connection::onClose(Client_Type* client_ptr, Connection_Handle hdl) {
-    std::cout << "### triggered onClose!\n";
+    LOG_DEBUG("triggered onClose");
     state_ = Connection_State_Values::closed;
 
     Client_Type::connection_ptr websocket_ptr { client_ptr->get_con_from_hdl(hdl) };
@@ -114,7 +117,7 @@ void Connection::onClose(Client_Type* client_ptr, Connection_Handle hdl) {
 }
 
 void Connection::onFail(Client_Type* client_ptr, Connection_Handle hdl) {
-    std::cout << "### triggered onFail!\n";
+    LOG_DEBUG("triggered onFail");
 
     state_ = Connection_State_Values::closed;
     Client_Type::connection_ptr websocket_ptr { client_ptr->get_con_from_hdl(hdl) };
@@ -126,7 +129,7 @@ void Connection::onFail(Client_Type* client_ptr, Connection_Handle hdl) {
 
 void Connection::onMessage(Client_Type* client_ptr, Connection_Handle hdl,
                            Client_Type::message_ptr msg) {
-    std::cout << "### triggered onMessage!\n" << msg->get_payload() << std::endl;
+    LOG_DEBUG("triggered onMessage:\n%1%", msg->get_payload());
 
     onMessage_callback_(client_ptr, shared_from_this(), msg->get_payload());
 }

--- a/src/connection_manager.cpp
+++ b/src/connection_manager.cpp
@@ -1,5 +1,8 @@
 #include "connection_manager.h"
 #include "errors.h"
+#include "log/log.h"
+
+LOG_DECLARE_NAMESPACE("client.connection_manager");
 
 namespace Cthun {
 namespace Client {
@@ -15,7 +18,7 @@ void ConnectionManager::configureSecureEndpoint(const std::string& ca_crt_path,
     if (endpoint_running_) {
         // TODO(ale): should we throw a client_error to let the caller
         // reset the endpoint?
-        std::cout << "### WARNING: an endpoint has already started\n";
+        LOG_WARNING("an endpoint has already started");
     }
     is_secure_ = true;
     ca_crt_path_ = ca_crt_path;

--- a/src/log/log.cpp
+++ b/src/log/log.cpp
@@ -1,11 +1,4 @@
 #include "log.h"
-#include <vector>
-
-
-
-// TODO(ale): todo!
-
-
 
 // boost includes are not always warning-clean. Disable warnings that
 // cause problems before including the headers, then re-enable the warnings.
@@ -13,6 +6,7 @@
 #pragma GCC diagnostic ignored "-Wextra"
 
 #include <boost/log/support/date_time.hpp>
+#include <boost/log/expressions/attr.hpp>
 #include <boost/log/expressions/formatters/date_time.hpp>
 #include <boost/log/utility/setup/console.hpp>
 #include <boost/log/utility/setup/common_attributes.hpp>
@@ -20,59 +14,119 @@
 #include <boost/log/sources/severity_logger.hpp>
 #include <boost/log/sources/record_ostream.hpp>
 #include <boost/log/attributes/scoped_attribute.hpp>
+#include <boost/log/attributes/current_thread_id.hpp>
+
+#include <vector>
+#include <unistd.h>
 
 #pragma GCC diagnostic pop
 
-using namespace std;
-using boost::format;
-namespace expr = boost::log::expressions;
-namespace src = boost::log::sources;
-namespace keywords = boost::log::keywords;
-
 namespace Cthun {
-namespace Log {
 
-
-bool is_log_enabled(const std::string &logger, log_level level) {
+bool Log::is_log_enabled(const std::string &logger, Log::log_level level) {
     // If the severity_logger returns a record for the specified
     // level, logging is enabled. Otherwise it isn't.
     // This is the guard call used in BOOST_LOG_SEV; see
-    // http://www.boost.org/doc/libs/1_54_0/libs/log/doc/html/log/detailed/sources.html
-    src::severity_logger<log_level> slg;
-    return (slg.open_record(keywords::severity = level) ? true : false);
+    // www.boost.org/doc/libs/1_54_0/libs/log/doc/html/log/detailed/sources.html
+    boost::log::sources::severity_logger<Log::log_level> slg;
+    return (slg.open_record(boost::log::keywords::severity = level) ? true : false);
 }
 
-void configure_logging(facter::logging::log_level level, ostream &dst)
-{
+void Log::configure_logging(Log::log_level level, std::ostream &dst) {
     // Set filtering based on log_level (info, warning, debug, etc).
     auto sink = boost::log::add_console_log(dst);
 
-    sink->set_formatter(
-        expr::stream
-            << expr::format_date_time<boost::posix_time::ptime>("TimeStamp", "%Y-%m-%d %H:%M:%S.%f")
-            << " " << left << setfill(' ') << setw(5) << facter::logging::log_level_attr
-            << " " << facter::logging::namespace_attr
-            << " - " << expr::smessage);
+    sink->set_formatter(boost::log::expressions::stream
+        << boost::log::expressions::format_date_time<boost::posix_time::ptime>(
+            "TimeStamp", "%Y-%m-%d %H:%M:%S.%f")
+        << " " << boost::log::expressions::attr<
+            boost::log::attributes::current_thread_id::value_type>("ThreadID")
+        << " " << std::left << std::setfill(' ') << std::setw(5)
+        << Log::log_level_attr << " "
+        << Log::namespace_attr << " - "
+        << boost::log::expressions::smessage);
 
-    sink->set_filter(facter::logging::log_level_attr >= level);
+    sink->set_filter(log_level_attr >= level);
     boost::log::add_common_attributes();
 }
 
-std::ostream& operator<<(std::ostream& strm, log_level level)
-{
-    std::vector<std::string> strings = {"TRACE", "DEBUG", "INFO", "WARN", "ERROR", "FATAL"};
-    if (static_cast<size_t>(level) < strings.size()) {
-        strm << strings[static_cast<size_t>(level)];
+std::ostream& Log::operator<<(std::ostream& strm, Log::log_level level) {
+    std::vector<std::string> levels {
+        "TRACE", "DEBUG", "INFO", "WARN", "ERROR", "FATAL" };
+    if (static_cast<size_t>(level) < levels.size()) {
+        strm << levels[static_cast<size_t>(level)];
     } else {
         strm << static_cast<int>(level);
     }
     return strm;
 }
 
-void log(const string &logger, log_level level, format& message)
-{
+void Log::log(const std::string &logger, Log::log_level level,
+              boost::format& message) {
     log(logger, level, message.str());
 }
 
+//
+// POSIX implementation of log()
+//
+
+// HERE(ale): we don't have the Win32 implementation; see cfacter
+
+static std::string cyan(std::string const& message) {
+    return "\33[0;36m" + message + "\33[0m";
+}
+
+static std::string green(std::string const& message) {
+    return "\33[0;32m" + message + "\33[0m";
+}
+
+static std::string yellow(std::string const& message) {
+    return "\33[0;33m" + message + "\33[0m";
+}
+
+static std::string red(std::string const& message) {
+    return "\33[0;31m" + message + "\33[0m";
+}
+
+// TODO(ale): pass the line number
+
+void Log::log(const std::string &logger, Log::log_level level,
+              std::string const& message) {
+    boost::log::sources::severity_logger<Log::log_level> slg;
+    slg.add_attribute("Namespace",
+                      boost::log::attributes::constant<std::string>(logger));
+
+    static bool color = isatty(fileno(stderr));
+    if (!color) {
+        BOOST_LOG_SEV(slg, level) << message;
+        return;
+    }
+
+    // TODO(ale): log line number
+
+    switch (level) {
+        case Log::log_level::trace:
+            BOOST_LOG_SEV(slg, level) << cyan(message);
+            break;
+        case Log::log_level::debug:
+            BOOST_LOG_SEV(slg, level) << cyan(message);
+            break;
+        case Log::log_level::info:
+            BOOST_LOG_SEV(slg, level) << green(message);
+            break;
+        case Log::log_level::warning:
+            BOOST_LOG_SEV(slg, level) << yellow(message);
+            break;
+        case Log::log_level::error:
+            BOOST_LOG_SEV(slg, level) << red(message);
+            break;
+        case Log::log_level::fatal:
+            BOOST_LOG_SEV(slg, level) << red(message);
+            break;
+        default:
+            BOOST_LOG_SEV(slg, level) << "Invalid logging level used.";
+            break;
+    }
+}
+
 }  // namespace Cthun
-}  // namespace Log

--- a/src/log/log.h
+++ b/src/log/log.h
@@ -1,10 +1,9 @@
 #ifndef CTHUN_CLIENT_SRC_LOG_LOG_H_
 #define CTHUN_CLIENT_SRC_LOG_LOG_H_
 
+// HERE(ale): this code was originally copied from cfacter
 
-
-// TODO(ale): todo! So far, this is the same as the cfacter one.
-
+// TODO(ale): change "//**" to "///" for doc consistency (?)
 
 // To use this header, you must:
 // - Have Boost on the include path
@@ -15,22 +14,27 @@
  * See Boost.Log's documentation.
  */
 #define BOOST_LOG_DYN_LINK
+
 #include <boost/log/core.hpp>
 #include <boost/log/expressions.hpp>
 #include <boost/format.hpp>
+
 #include <cstdio>
+#include <string>
 
 /**
  * Defines the root logging namespace.
  */
-#define LOG_ROOT_NAMESPACE "puppetlabs.cthun.client."
+#define LOG_ROOT_NAMESPACE "puppetlabs.cthun."
 
 /**
  * Used to declare a logging namespace for a source file.
  * This macro must be used before any other logging macro.
  * @param ns The logging namespace name.
  */
-#define LOG_DECLARE_NAMESPACE(ns) static const std::string g_logger = LOG_ROOT_NAMESPACE ns;
+#define LOG_DECLARE_NAMESPACE(ns) static const std::string g_logger = \
+    LOG_ROOT_NAMESPACE ns;
+
 /**
  * Logs a message.
  * @param level The logging level for the message.
@@ -38,82 +42,109 @@
  * @param ... The format message parameters.
  */
 #define LOG_MESSAGE(level, format, ...) \
-    if (facter::logging::is_log_enabled(g_logger, level)) { \
-        facter::logging::log(g_logger, level, format, ##__VA_ARGS__); \
+    if (Cthun::Log::is_log_enabled(g_logger, level)) { \
+        Cthun::Log::log(g_logger, level, format, ##__VA_ARGS__); \
     }
+
 /**
  * Logs a trace message.
  * @param format The format message.
  * @param ... The format message parameters.
  */
-#define LOG_TRACE(format, ...) LOG_MESSAGE(facter::logging::log_level::trace, format, ##__VA_ARGS__)
+#define LOG_TRACE(format, ...) LOG_MESSAGE(Cthun::Log::log_level::trace, \
+                                           format, ##__VA_ARGS__)
+
 /**
  * Logs a debug message.
  * @param format The format message.
  * @param ... The format message parameters.
  */
-#define LOG_DEBUG(format, ...) LOG_MESSAGE(facter::logging::log_level::debug, format, ##__VA_ARGS__)
+#define LOG_DEBUG(format, ...) LOG_MESSAGE(Cthun::Log::log_level::debug, \
+                                           format, ##__VA_ARGS__)
+
 /**
  * Logs an info message.
  * @param format The format message.
  * @param ... The format message parameters.
  */
-#define LOG_INFO(format, ...) LOG_MESSAGE(facter::logging::log_level::info, format, ##__VA_ARGS__)
+#define LOG_INFO(format, ...) LOG_MESSAGE(Cthun::Log::log_level::info, \
+                                          format, ##__VA_ARGS__)
+
 /**
  * Logs a warning message.
  * @param format The format message.
  * @param ... The format message parameters.
  */
-#define LOG_WARNING(format, ...) LOG_MESSAGE(facter::logging::log_level::warning, format, ##__VA_ARGS__)
+#define LOG_WARNING(format, ...) LOG_MESSAGE(Cthun::Log::log_level::warning, \
+                                             format, ##__VA_ARGS__)
+
 /**
  * Logs an error message.
  * @param format The format message.
  * @param ... The format message parameters.
  */
-#define LOG_ERROR(format, ...) LOG_MESSAGE(facter::logging::log_level::error, format, ##__VA_ARGS__)
+#define LOG_ERROR(format, ...) LOG_MESSAGE(Cthun::Log::log_level::error, \
+                                           format, ##__VA_ARGS__)
+
 /**
  * Logs a fatal message.
  * @param format The format message.
  * @param ... The format message parameters.
  */
-#define LOG_FATAL(format, ...) LOG_MESSAGE(facter::logging::log_level::fatal, format, ##__VA_ARGS__)
+#define LOG_FATAL(format, ...) LOG_MESSAGE(Cthun::Log::log_level::fatal, \
+                                           format, ##__VA_ARGS__)
+
 /**
  * Determines if the given logging level is enabled.
  * @param level The logging level to check.
  */
-#define LOG_IS_ENABLED(level) facter::logging::is_log_enabled(g_logger, level)
+#define LOG_IS_ENABLED(level) Cthun::Log::is_log_enabled(g_logger, level)
+
 /**
  * Determines if the trace logging level is enabled.
- * @returns Returns true if trace logging is enabled or false if it is not enabled.
+ * @returns Returns true if trace logging is enabled or false if it is
+ * not enabled.
  */
-#define LOG_IS_TRACE_ENABLED() LOG_IS_ENABLED(facter::logging::log_level::trace)
+#define LOG_IS_TRACE_ENABLED() LOG_IS_ENABLED(Cthun::Log::log_level::trace)
+
 /**
  * Determines if the debug logging level is enabled.
- * @returns Returns true if debug logging is enabled or false if it is not enabled.
+ * @returns Returns true if debug logging is enabled or false if it is
+ * not enabled.
  */
-#define LOG_IS_DEBUG_ENABLED() LOG_IS_ENABLED(facter::logging::log_level::debug)
+#define LOG_IS_DEBUG_ENABLED() LOG_IS_ENABLED(Cthun::Log::log_level::debug)
+
 /**
  * Determines if the info logging level is enabled.
- * @returns Returns true if info logging is enabled or false if it is not enabled.
+ * @returns Returns true if info logging is enabled or false if it is
+ * not enabled.
  */
-#define LOG_IS_INFO_ENABLED() LOG_IS_ENABLED(facter::logging::log_level::info)
+#define LOG_IS_INFO_ENABLED() LOG_IS_ENABLED(Cthun::Log::log_level::info)
+
 /**
  * Determines if the warning logging level is enabled.
- * @returns Returns true if warning logging is enabled or false if it is not enabled.
+ * @returns Returns true if warning logging is enabled or false if it
+ * is not enabled.
  */
-#define LOG_IS_WARNING_ENABLED() LOG_IS_ENABLED(facter::logging::log_level::warning)
+#define LOG_IS_WARNING_ENABLED() LOG_IS_ENABLED(Cthun::Log::log_level::warning)
+
 /**
  * Determines if the error logging level is enabled.
- * @returns Returns true if error logging is enabled or false if it is not enabled.
+ * @returns Returns true if error logging is enabled or false if it is
+ *not enabled.
  */
-#define LOG_IS_ERROR_ENABLED() LOG_IS_ENABLED(facter::logging::log_level::error)
+#define LOG_IS_ERROR_ENABLED() LOG_IS_ENABLED(Cthun::Log::log_level::error)
+
 /**
  * Determines if the fatal logging level is enabled.
- * @returns Returns true if fatal logging is enabled or false if it is not enabled.
+ * @returns Returns true if fatal logging is enabled or false if it is
+ * not enabled.
  */
-#define LOG_IS_FATAL_ENABLED() LOG_IS_ENABLED(facter::logging::log_level::fatal)
+#define LOG_IS_FATAL_ENABLED() LOG_IS_ENABLED(Cthun::Log::log_level::fatal)
 
-// TODO(ale): correct namespace?
+//
+// namespace Cthun::Log
+//
 
 namespace Cthun {
 namespace Log {
@@ -121,8 +152,7 @@ namespace Log {
 /**
  * Represents the supported logging levels.
  */
-enum class log_level
-{
+enum class log_level {
     trace,
     debug,
     info,
@@ -138,6 +168,7 @@ enum class log_level
  * name "Severity" of log_level_attr is tied to BOOST_LOG_SEV.
  */
 BOOST_LOG_ATTRIBUTE_KEYWORD(log_level_attr, "Severity", log_level);
+
 /**
  * The Boost.Log attribute for namespace.
  */
@@ -162,7 +193,8 @@ void configure_logging(log_level level, std::ostream &dst);
  * Determines if the given log level is enabled for the given logger.
  * @param logger The logger to check.
  * @param level The logging level to check.
- * @return Returns true if the logging level is enabled or false if it is not.
+ * @return Returns true if the logging level is enabled or false if it
+ * is not.
  */
 bool is_log_enabled(const std::string &logger, log_level level);
 
@@ -172,7 +204,8 @@ bool is_log_enabled(const std::string &logger, log_level level);
  * @param level The logging level to log with.
  * @param message The message to log.
  */
-void log(const std::string &logger, log_level level, std::string const& message);
+void log(const std::string &logger, log_level level,
+         std::string const& message);
 
 /**
  * Logs a given format message to the given logger.
@@ -180,7 +213,8 @@ void log(const std::string &logger, log_level level, std::string const& message)
  * @param level The logging level to log with.
  * @param message The message being formatted.
  */
-void log(const std::string &logger, log_level level, boost::format& message);
+void log(const std::string &logger, log_level level,
+         boost::format& message);
 
 /**
  * Logs a given format message to the given logger.
@@ -193,8 +227,8 @@ void log(const std::string &logger, log_level level, boost::format& message);
  * @param args The remaining arguments to the message.
  */
 template <typename T, typename... TArgs>
-void log(const std::string &logger, log_level level, boost::format& message, T arg, TArgs... args)
-{
+void log(const std::string &logger, log_level level,
+         boost::format& message, T arg, TArgs... args) {
     message % arg;
     log(logger, level, message, std::forward<TArgs>(args)...);
 }
@@ -208,13 +242,13 @@ void log(const std::string &logger, log_level level, boost::format& message, T a
  * @param args The remaining arguments to the message.
  */
 template <typename... TArgs>
-void log(const std::string &logger, log_level level, std::string const& format, TArgs... args)
-{
+void log(const std::string &logger, log_level level,
+         std::string const& format, TArgs... args) {
     boost::format message(format);
     log(logger, level, message, std::forward<TArgs>(args)...);
 }
 
-}  // namespace Cthun
 }  // namespace Log
+}  // namespace Cthun
 
 #endif  // CTHUN_CLIENT_SRC_LOG_LOG_H_


### PR DESCRIPTION
Enabling log/log.h based on boost::log (same as cfacter). Disabling
websocketpp logging. Adding thread ID to format. New configuration.h.
