### PR TITLE
(CTH-52) - Handling ping / pong messages

### DIFF
--- a/src/configuration.h
+++ b/src/configuration.h
@@ -10,7 +10,7 @@ namespace Client {
 namespace Configuration {
 
 static const Log::log_level DEFAULT_LOG_LEVEL { Log::log_level::info };
-static std::ostream& DEFAULT_LOG_STREAM = std::cout ;
+static std::ostream& DEFAULT_LOG_STREAM = std::cout;
 
 // TODO(ale): allow configuring log to file
 

--- a/src/connection_manager.cpp
+++ b/src/connection_manager.cpp
@@ -59,6 +59,12 @@ void ConnectionManager::send(Connection::Ptr connection_ptr, Message message) {
     endpoint_ptr_->send(connection_ptr, message);
 }
 
+void ConnectionManager::ping(Connection::Ptr connection_ptr,
+                             const std::string& binary_payload) {
+    startEndpointIfNeeded();
+    endpoint_ptr_->ping(connection_ptr, binary_payload);
+}
+
 void ConnectionManager::close(Connection::Ptr connection_ptr,
                               Close_Code code, Message reason) {
     startEndpointIfNeeded();

--- a/src/connection_manager.h
+++ b/src/connection_manager.h
@@ -46,6 +46,11 @@ class ConnectionManager {
     /// Throw a message_error in case of failure.
     void send(Connection::Ptr connection_ptr, Message message);
 
+    /// Ping the other endpoint of the pointed connection.
+    /// Throw a message_error in case of failure.
+    void ping(Connection::Ptr connection_ptr,
+              const std::string& binary_payload);
+
     /// Close the pointed connection; reason and code are optional
     /// (respectively default to "Closed by client" and normal as
     /// in rfc6455).

--- a/src/endpoint.h
+++ b/src/endpoint.h
@@ -32,11 +32,14 @@ class Endpoint {
     /// Throw a connection_error in case of failure.
     void open(Connection::Ptr connection_ptr);
 
-    // TODO(ale): send binary message; Message class;
-
     /// Send message on the specified connection.
     /// Throw a message_error in case of failure.
     void send(Connection::Ptr connection_ptr, std::string msg);
+
+    /// Ping the other endpoint of the specified connection.
+    /// Throw a message_error in case of failure.
+    void ping(Connection::Ptr connection_ptr,
+              const std::string& binary_payload);
 
     /// Close the specified connection; reason and code are optional
     /// (respectively default to "Closed by client" and 'normal' as


### PR DESCRIPTION
Implementing: ping/pong/pongTimeout callbacks; Endpoint::ping();
Connection::waitForOpen(). TRACE instead of DEBUG for msg logs.
