### PR TITLE
Add ContentType to Schema

### DIFF
--- a/src/validator/schema.cpp
+++ b/src/validator/schema.cpp
@@ -31,6 +31,10 @@ void Schema::addConstraint(std::string field, Schema sub_schema, bool required) 
     }
 }
 
+ContentType Schema::getContentType() const {
+    return content_type_;
+}
+
 const valijson::Schema Schema::getRaw() const {
     valijson::Schema schema;
 

--- a/src/validator/schema.h
+++ b/src/validator/schema.h
@@ -9,12 +9,15 @@ namespace CthunClient {
 namespace V_C = valijson::constraints;
 
 enum class TypeConstraint { Object, Array, String, Int, Bool, Double, Null, Any };
+enum class ContentType { Json, Binary };
 
 class Schema {
   public:
-    Schema() {};
+    Schema() : content_type_(ContentType::Json) {};
+    Schema(ContentType content_type) : content_type_(content_type) {};
     void addConstraint(std::string field, TypeConstraint type, bool required = false);
     void addConstraint(std::string field, Schema sub_schema, bool required = false);
+    ContentType getContentType() const;
     const valijson::Schema getRaw() const;
 
   private:
@@ -23,6 +26,7 @@ class Schema {
     V_C::RequiredConstraint::RequiredProperties required_properties_;
 
     V_C::TypeConstraint getConstraint(TypeConstraint type) const;
+    ContentType content_type_;
 };
 
 }  // namespace CthunClient

--- a/src/validator/validator.h
+++ b/src/validator/validator.h
@@ -17,9 +17,14 @@ class validator_error : public std::runtime_error  {
     explicit validator_error(std::string const& msg) : std::runtime_error(msg) {}
 };
 
-class register_error : public validator_error  {
+class schema_redefinition_error : public validator_error  {
   public:
-    explicit register_error(std::string const& msg) : validator_error(msg) {}
+    explicit schema_redefinition_error(std::string const& msg) : validator_error(msg) {}
+};
+
+class schema_not_found_error : public validator_error  {
+  public:
+    explicit schema_not_found_error(std::string const& msg) : validator_error(msg) {}
 };
 
 class validation_error : public validator_error {
@@ -34,9 +39,10 @@ class Validator {
         return instance;
     }
 
-    void registerSchema(std::string name, Schema schema);
-    void validate(DataContainer& data, std::string schema) const;
+    void registerSchema(const std::string& schema_name, const Schema& schema);
+    void validate(DataContainer& data, std::string schema_name) const;
     bool includesSchema(std::string schema_name) const;
+    ContentType getSchemaContentType(std::string schema_name) const;
     void reset();
 
   private:

--- a/test/unit/validator/schema_test.cpp
+++ b/test/unit/validator/schema_test.cpp
@@ -109,4 +109,9 @@ TEST_CASE("Schema::addConstraint(subschema)", "[addConstraint]") {
     }
 }
 
+TEST_CASE("Schema::getContentType()", "[getContentType]") {
+    Schema schema { ContentType::Binary };
+    REQUIRE(schema.getContentType() == ContentType::Binary);
+}
+
 }  // namespace CthunClient

--- a/test/unit/validator/validator_test.cpp
+++ b/test/unit/validator/validator_test.cpp
@@ -17,7 +17,7 @@ TEST_CASE("Validator::registerSchema", "[registerSchema]") {
     SECTION("it cannot register a schema name more than once") {
         Validator::Instance().registerSchema("test-schema", schema);
         REQUIRE_THROWS_AS(Validator::Instance().registerSchema("test-schema", schema),
-                          register_error);
+                          schema_redefinition_error);
     }
 }
 
@@ -62,6 +62,22 @@ TEST_CASE("Validator::validate", "[validate]") {
             data.set<std::string>("id", "1234");
         REQUIRE_THROWS_AS(Validator::Instance().validate(data, "envelope"),
                           validation_error);        }
+    }
+}
+
+TEST_CASE("Validator::getSchemaContentType", "[getSchemaContentType]") {
+    Schema schema { ContentType::Binary };
+    Validator::Instance().reset();
+
+    SECTION("it can return the schema's content type") {
+        Validator::Instance().registerSchema("test-schema", schema);
+        REQUIRE(Validator::Instance().getSchemaContentType("test-schema") ==
+                ContentType::Binary);
+    }
+
+    SECTION("it throws when the schema is undefined") {
+        REQUIRE_THROWS_AS(Validator::Instance().getSchemaContentType("test-schema"),
+                         schema_not_found_error);
     }
 }
 


### PR DESCRIPTION
This commit allows Schemas to define a ContentType that will be used
during parsing of the message body.

It also adds a getSchemaContentType method to the validator.
