### PR TITLE
Properly cast document_root to Value

### DIFF
--- a/src/cthun-client/data_container/data_container.h
+++ b/src/cthun-client/data_container/data_container.h
@@ -118,7 +118,7 @@ class DataContainer {
 
     template <typename T>
     T get() {
-        return getValue<T>(document_root_);
+        return getValue<T>(*reinterpret_cast<rapidjson::Value*>(document_root_.get()));
     }
 
     template <typename T>

--- a/test/unit/data_container/data_container_test.cpp
+++ b/test/unit/data_container/data_container_test.cpp
@@ -48,6 +48,10 @@ TEST_CASE("DataContainer::get", "[data]") {
         REQUIRE(tmp[1] == result[1]);
     }
 
+    SECTION("it can get the root object") {
+      REQUIRE(msg.get<DataContainer>().get<int>("goo") == 1);
+    }
+
     SECTION("it should behave correctly given a null value") {
         REQUIRE(msg.get<std::string>("null") == "");
         REQUIRE(msg.get<int>("null") == 0);


### PR DESCRIPTION
When retrieving the current value rather than a key, the document_root
was not properly being converted from a unique_ptr<Document> to a Value.
