### PR TITLE
(CTH-198) Build with GCC 4.8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
 
     # NB: -pthread is needed for fedora20 (cmake does not add the library, even
     # afer finding it)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wextra -Werror -Wno-unused-parameter -Wno-sign-compare -lpthread -pthread")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wextra -Werror -Wno-unused-parameter -Wno-sign-compare -Wno-reorder -lpthread -pthread -fPIC")
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
 endif()
@@ -48,6 +48,21 @@ set(LEATHERMAN_USE_CATCH TRUE)
 set(LEATHERMAN_USE_LOGGING TRUE)
 add_subdirectory("vendor/leatherman")
 
+# Find libraries
+find_package(Boost 1.54 REQUIRED
+  COMPONENTS filesystem system date_time thread log regex random)
+
+find_package(OpenSSL REQUIRED)
+
+# prefer openssl from ports
+if ("${CMAKE_SYSTEM_NAME}" MATCHES "Darwin")
+    set(CMAKE_LIBRARY_PATH ${CMAKE_LIBRARY_PATH} /opt/local/lib)
+    set(CMAKE_INCLUDE_PATH ${CMAKE_INCLUDE_PATH} /opt/local/include)
+else()
+    set(CMAKE_LIBRARY_PATH ${CMAKE_LIBRARY_PATH} /usr/lib)
+    set(CMAKE_INCLUDE_PATH ${CMAKE_INCLUDE_PATH} /usr/include)
+endif()
+
 # Include vendor libraries and directories
 include(${VENDOR_DIRECTORY}/websocketpp.cmake)
 include(${VENDOR_DIRECTORY}/rapidjson.cmake)
@@ -59,23 +74,12 @@ include_directories(
     ${VALIJSON_INCLUDE_DIRS}
     ${WEBSOCKETPP_INCLUDE_DIRS}
     ${LEATHERMAN_INCLUDE_DIRS}
+    ${OPENSSL_INCLUDE_DIR}
 )
 
 link_directories(
     ${Boost_LIBRARY_DIRS}
 )
-
-# Find libraries
-find_package(Boost 1.54 REQUIRED
-  COMPONENTS filesystem system date_time thread log regex random)
-
-find_package(OpenSSL REQUIRED)
-
-# prefer openssl from ports
-if ("${CMAKE_SYSTEM_NAME}" MATCHES "Darwin")
-    set(CMAKE_LIBRARY_PATH ${CMAKE_LIBRARY_PATH} /opt/local/lib)
-    set(CMAKE_INCLUDE_PATH ${CMAKE_INCLUDE_PATH} /opt/local/include)
-endif()
 
 # Add src subdirectory
 add_subdirectory(src)

--- a/README.md
+++ b/README.md
@@ -74,17 +74,17 @@ The folling calls to the _get_ method will retrieve values from the DataContaine
 
 ```
     data.get<std::string>("module"); // == "puppet"
-    data.get<std::string>("params", "first"); // == "--module-path=/home/alice/modules"
+    data.get<std::string>({ "params", "first" }); // == "--module-path=/home/alice/modules"
 ```
 
-Note that the _get_ method is variadic and each additional argument is a level down
-in the JSON document.
+Note that when the _get_ method is invoked with an initialiser list it will use
+each argument to descend a level into the object tree.
 
 You can also set the value of fields and create new fields with the _set_ method.
 
 ```
     data.set<int>("foo", 42);
-    data.set<bool>("params", "second", false);
+    data.set<bool>({ "params", "second" }, false);
 ```
 
 This will change the internal JSON representation to
@@ -101,8 +101,8 @@ This will change the internal JSON representation to
     }
 ```
 
-Note that the _set_ method is also variadic with the depth in the object tree being
-determined by all but the last parameter, which is the value.
+Note that the _set_ method uses the initialiser list in the same way as the _get_
+method. Each argument to the list is one level to descend.
 
 The _get_ and _set_ methods can throw the following exceptions:
 

--- a/src/cthun-client/connector/client_metadata.cpp
+++ b/src/cthun-client/connector/client_metadata.cpp
@@ -5,7 +5,7 @@
 
 #include <leatherman/logging/logging.hpp>
 
-#include <openssl/X509v3.h>
+#include <openssl/x509v3.h>
 #include <openssl/ssl.h>
 
 #include <stdio.h>  // std::fopen

--- a/src/cthun-client/data_container/data_container.cpp
+++ b/src/cthun-client/data_container/data_container.cpp
@@ -77,9 +77,8 @@ bool DataContainer::hasKey(const rapidjson::Value& jval, const char* key) const 
     return (jval.IsObject() && jval.HasMember(key));
 }
 
-bool DataContainer::isNotObject(const rapidjson::Value& jval,
-                                const char* key) const {
-    return (jval.HasMember(key) && !getValueInJson(jval, key)->IsObject());
+bool DataContainer::isObject(const rapidjson::Value& jval) const {
+    return jval.IsObject();
 }
 
 rapidjson::Value* DataContainer::getValueInJson(const rapidjson::Value& jval,

--- a/src/cthun-client/validator/schema.cpp
+++ b/src/cthun-client/validator/schema.cpp
@@ -65,8 +65,7 @@ Schema::Schema(const Schema& s)
             new V_C::RequiredConstraint::RequiredProperties(*s.required_properties_)} {
 }
 
-const Schema::Schema(const std::string& name,
-                     const DataContainer metadata)
+Schema::Schema(const std::string& name, const DataContainer metadata)
         try : name_ { name },
               content_type_ { ContentType::Json },
               parsed_json_schema_ { new valijson::Schema(parseSchema(metadata)) },
@@ -161,7 +160,7 @@ V_C::TypeConstraint Schema::getConstraint(TypeConstraint type) const {
             return V_C::TypeConstraint::kNumber;
         case TypeConstraint::Null :
             return V_C::TypeConstraint::kNull;
-        case TypeConstraint::Any :
+        default:
             return V_C::TypeConstraint::kAny;
     }
 }

--- a/src/cthun-client/validator/schema.h
+++ b/src/cthun-client/validator/schema.h
@@ -69,10 +69,8 @@ class Schema {
     // Instantiate a Schema of type ContentType::Json by parsing the
     // JSON schema passed as a DataContainer object.
     // It won't be possible to add further constraints to such schema
-    // (hence the const modifier, even though ineffective).
     // Throw a schema_error in case of parsing failure.
-    const Schema(const std::string& name,
-                 const DataContainer json_schema);
+    Schema(const std::string& name, const DataContainer json_schema);
 
     // Add constraints to a JSON object schema.
     // Throw a schema_error in case the Schema instance is not of

--- a/test/unit/data_container/data_container_test.cpp
+++ b/test/unit/data_container/data_container_test.cpp
@@ -26,7 +26,7 @@ TEST_CASE("DataContainer::get", "[data]") {
     }
 
     SECTION("it can get a nested value") {
-        REQUIRE(msg.get<int>("foo", "bar") == 2);
+        REQUIRE(msg.get<int>({"foo", "bar"}) == 2);
     }
 
     SECTION("it can get a bool value") {
@@ -61,8 +61,8 @@ TEST_CASE("DataContainer::get", "[data]") {
     SECTION("it returns a null like value when indexing something that "
             "doesn't exist") {
         REQUIRE(msg.get<std::string>("invalid") == "");
-        REQUIRE(msg.get<int>("goo", "1") == 0);
-        REQUIRE(msg.get<bool>("foo", "baz") == false);
+        REQUIRE(msg.get<int>({ "goo", "1" }) == 0);
+        REQUIRE(msg.get<bool>({ "foo", "baz" }) == false);
     }
 }
 
@@ -70,13 +70,13 @@ TEST_CASE("DataContainer::includes", "[data]") {
     SECTION("Document/object lookups") {
         DataContainer msg { JSON };
         REQUIRE(msg.includes("foo") == true);
-        REQUIRE(msg.includes("foo", "bar") == true);
-        REQUIRE(msg.includes("foo", "baz") == false);
+        REQUIRE(msg.includes({ "foo", "bar" }) == true);
+        REQUIRE(msg.includes({ "foo", "baz" }) == false);
     }
 
     SECTION("Non object/document lookups") {
         DataContainer msg { "\"foo\"" };
-        REQUIRE(msg.includes("bar", "bar") == false);
+        REQUIRE(msg.includes({ "bar", "bar" }) == false);
         REQUIRE(msg.includes("foo") == false);
     }
 }
@@ -90,13 +90,13 @@ TEST_CASE("DataContainer::set", "[data]") {
     }
 
     SECTION("it allows the creation of a nested structure") {
-        msg.set<int>("level1", "level21", 0);
+        msg.set<int>({"level1", "level21"}, 0);
         msg.set<bool>("bool1", true);
-        msg.set<std::string>("level1", "level22", "a string");
+        msg.set<std::string>({"level1", "level22"}, "a string");
         msg.set<std::string>("level11", "different string");
-        REQUIRE(msg.get<int>("level1", "level21") == 0);
+        REQUIRE(msg.get<int>({ "level1", "level21" }) == 0);
         REQUIRE(msg.get<bool>("bool1") == true);
-        REQUIRE(msg.get<std::string>("level1", "level22") == "a string");
+        REQUIRE(msg.get<std::string>({"level1", "level22"}) == "a string");
         REQUIRE(msg.get<std::string>("level11") == "different string");
     }
 


### PR DESCRIPTION
This commit simplifies the DataContainer class from using variadic
templates to initialiser lists from object traversal. As much as I
preferred the clean interface of the variadic templates gcc just
couldn't cope.

This commit also fixes some includes (gcc wants <memory> when you're
using smart pointers).

Also update compiler flags and find boost in the right place.
