### PR TITLE
(CTH-205) Add DataContainer::type() overload

### DIFF
--- a/lib/inc/cthun-client/data_container/data_container.hpp
+++ b/lib/inc/cthun-client/data_container/data_container.hpp
@@ -148,6 +148,8 @@ class DataContainer {
     // NOTE(ale): we don't use const for the arg below for gcc issues
     bool includes(std::vector<DataContainerKey> keys) const;
 
+    DataType type() const;
+
     /// Throw a data_key_error in case the specified key is unknown.
     DataType type(const DataContainerKey& key) const;
 

--- a/lib/src/data_container/data_container.cc
+++ b/lib/src/data_container/data_container.cc
@@ -108,6 +108,11 @@ bool DataContainer::includes(std::vector<DataContainerKey> keys) const {
     return true;
 }
 
+DataType DataContainer::type() const {
+    rapidjson::Value* jval = reinterpret_cast<rapidjson::Value*>(document_root_.get());
+    return getValueType(*jval);
+}
+
 DataType DataContainer::type(const DataContainerKey& key) const {
     rapidjson::Value* jval = reinterpret_cast<rapidjson::Value*>(document_root_.get());
 

--- a/lib/tests/unit/data_container/data_container_test.cc
+++ b/lib/tests/unit/data_container/data_container_test.cc
@@ -334,6 +334,23 @@ TEST_CASE("DataContainer::keys", "[data]") {
 TEST_CASE("DataContainer::type", "[data]") {
     DataContainer data {};
 
+    SECTION("When no key is passed it retrieves the type of the root value") {
+        SECTION("array") {
+            DataContainer data_array { "[1, 2, 3]" };
+            REQUIRE(data_array.type() == DataType::Array);
+        }
+
+        SECTION("object") {
+            data.set<bool>("b_entry", false);
+            REQUIRE(data.type() == DataType::Object);
+        }
+
+        SECTION("number") {
+            DataContainer data_number { "42" };
+            REQUIRE(data_number.type() == DataType::Int);
+        }
+    }
+
     SECTION("When a single key is passed") {
         SECTION("it throws a data_key_error if the key is unknown") {
             REQUIRE_THROWS_AS(data.type("foo"),


### PR DESCRIPTION
Adding type() overload without any argument that retrieves the type of
the root value.
