### PR TITLE
(maint) Update server URI in tutorial request

### DIFF
--- a/tutorial/09/controller/main.cpp
+++ b/tutorial/09/controller/main.cpp
@@ -154,7 +154,8 @@ void Controller::sendRequests() {
     // TODO(ale): use the complete server URI once we apply the specs
 
     try {
-        connector_ptr_->send(std::vector<std::string> { "cth://server" },
+        // NB: use "cth:///server" with 3 '/' as the server URI
+        connector_ptr_->send(std::vector<std::string> { "cth:///server" },
                              CthunClient::Protocol::INVENTORY_REQ_TYPE,
                              MSG_TIMEOUT_S,
                              inventory_request);


### PR DESCRIPTION
Fix the server URI used as target endpoint for an inventory request by
the controller of tutorial step #9.
