### PR TITLE
(maint) Simplify and record reason for valijson patching

### DIFF
--- a/vendor/valijson-rapidjson_adapter.patch
+++ b/vendor/valijson-rapidjson_adapter.patch
@@ -3,24 +3,12 @@ From: Richard Clamp <richardc@unixbeard.net>
 Date: Thu, 27 Nov 2014 17:10:07 +0000
 Subject: [PATCH] Fix for head
 
----
- CMakeLists.txt                                  | 2 +-
- include/valijson/adapters/rapidjson_adapter.hpp | 3 +--
- 2 files changed, 2 insertions(+), 3 deletions(-)
+Rapidjson HEAD changes some iterator stuff.
 
-diff --git a/CMakeLists.txt b/CMakeLists.txt
-index ead1a08..ef7ecf5 100644
---- a/CMakeLists.txt
-+++ b/CMakeLists.txt
-@@ -18,7 +18,7 @@ add_library(jsoncpp
- add_subdirectory(thirdparty/gtest-1.7.0)
- 
- # Include path
--include_directories(include thirdparty/gtest-1.7.0/include thirdparty/jsoncpp-0.5.0/include thirdparty/rapidjson-0.1/include)
-+include_directories(include thirdparty/gtest-1.7.0/include thirdparty/jsoncpp-0.5.0/include thirdparty/rapidjson-0.11/include)
- 
- # External schema validation example
- add_executable(external_schema
+We're carrying this until rapidjson ships a 1.0, then we should
+submit this upstream.
+
+
 diff --git a/include/valijson/adapters/rapidjson_adapter.hpp b/include/valijson/adapters/rapidjson_adapter.hpp
 index 9a0be0c..7e727d2 100644
 --- a/include/valijson/adapters/rapidjson_adapter.hpp


### PR DESCRIPTION
Win32 builds failing to apply the CMakeLists.txt section of this
patch.  It's strictly speaking uneeded for now, so edit it out of
the patch, and while we're there put a better note as to what the
patch is for.
