### PR TITLE
CTH-247 Windows doesn't have netinet/in.h

### DIFF
--- a/lib/inc/cpp-pcp-client/protocol/serialization.hpp
+++ b/lib/inc/cpp-pcp-client/protocol/serialization.hpp
@@ -8,7 +8,11 @@
 #include <string>
 #include <vector>
 #include <stdint.h>  // uint8_t
+#if _WIN32
+#include <Winsock2.h>
+#else
 #include <netinet/in.h>  // endianess functions: htonl, ntohl
+#endif
 #include <stdexcept>
 
 // TODO(ale): disable assert() once we're confident with the code...


### PR DESCRIPTION
According to
https://msdn.microsoft.com/en-us/library/windows/desktop/ms740069(v=vs.85).aspx the definitions are in Winsock2.h
