### PR TITLE
CTH-247 use auto instead of X509_NAME

### DIFF
--- a/lib/src/connector/client_metadata.cc
+++ b/lib/src/connector/client_metadata.cc
@@ -39,8 +39,8 @@ std::string getCommonNameFromCert(const std::string& client_crt_path) {
                                         + "' is invalid" };
     }
 
-    X509_NAME* subj = X509_get_subject_name(cert.get());
-    X509_NAME_ENTRY* name_entry = X509_NAME_get_entry(subj, 0);
+    auto subj = X509_get_subject_name(cert.get());
+    auto name_entry = X509_NAME_get_entry(subj, 0);
 
     if (name_entry == nullptr) {
         throw connection_config_error { "failed to retrieve the client common "


### PR DESCRIPTION
For some reason on win32 the X509_NAME macro isn't resolving.  See
if the compiler will figure it out for us.

```
[ 63%] Building CXX object vendor/leatherman/util/CMakeFiles/leatherman_util.dir/src/windows/environment.cc.obj
Linking CXX static library ..\..\..\lib\libleatherman_util.a
C:\cygwin64\home\Administrator\cpp-pcp-client\lib\src\connector\client_metadata.cc: In function 'std::string PCPClient::getCommonNameFromCert(const string&)':
C:\cygwin64\home\Administrator\cpp-pcp-client\lib\src\connector\client_metadata.cc:42:16: error: 'subj' was not declared in this scope
X509_NAME* subj = X509_get_subject_name(cert.get());
^
```
