### PR TITLE
(CTH-247) Avoid including windows headers in ours

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -15,6 +15,7 @@ set(SOURCES
     src/protocol/chunks.cc
     src/protocol/message.cc
     src/protocol/schemas.cc
+    src/protocol/serialization.cc
     src/validator/schema.cc
     src/validator/validator.cc
 )

--- a/lib/inc/cpp-pcp-client/protocol/serialization.hpp
+++ b/lib/inc/cpp-pcp-client/protocol/serialization.hpp
@@ -8,11 +8,6 @@
 #include <string>
 #include <vector>
 #include <stdint.h>  // uint8_t
-#if _WIN32
-#include <Winsock2.h>
-#else
-#include <netinet/in.h>  // endianess functions: htonl, ntohl
-#endif
 #include <stdexcept>
 
 // TODO(ale): disable assert() once we're confident with the code...
@@ -30,13 +25,8 @@ typedef std::vector<uint8_t> SerializedMessage;
 
 #ifdef BOOST_LITTLE_ENDIAN
 
-inline uint32_t getNetworkNumber(const uint32_t& number) {
-    return htonl(number);
-}
-
-inline uint32_t getHostNumber(const uint32_t& number) {
-    return ntohl(number);
-}
+uint32_t getNetworkNumber(const uint32_t& number);
+uint32_t getHostNumber(const uint32_t& number);
 
 #else  // we're using big endian (!)
 

--- a/lib/src/protocol/serialization.cc
+++ b/lib/src/protocol/serialization.cc
@@ -1,0 +1,22 @@
+#include <cpp-pcp-client/protocol/serialization.hpp>
+#if _WIN32
+#include <Winsock2.h>
+#else
+#include <netinet/in.h>  // endianess functions: htonl, ntohl
+#endif
+
+namespace PCPClient {
+
+#ifdef BOOST_LITTLE_ENDIAN
+
+uint32_t getNetworkNumber(const uint32_t& number) {
+    return htonl(number);
+}
+
+uint32_t getHostNumber(const uint32_t& number) {
+    return ntohl(number);
+}
+
+#endif  // BOOST_LITTLE_ENDIAN
+
+}  // namespace PCPClient


### PR DESCRIPTION
Windows header files do a bunch of nasty #defines that we'd like to avoid
in our header files. Move requirement for winsock.h to a source file.
