### PR TITLE
(PCP-31) Randomise reconnect timeout

### DIFF
--- a/lib/inc/cpp-pcp-client/connector/connection.hpp
+++ b/lib/inc/cpp-pcp-client/connector/connection.hpp
@@ -51,7 +51,7 @@ namespace PCPClient {
 // Constants
 
 static const std::string PING_PAYLOAD_DEFAULT { "" };
-static const uint32_t CONNECTION_BACKOFF_S { 2 };  // [s]
+static const uint32_t CONNECTION_BACKOFF_MS { 2000 };  // [ms]
 static const std::string DEFAULT_CLOSE_REASON { "Closed by client" };
 
 // Configuration of the WebSocket transport layer
@@ -173,7 +173,7 @@ class Connection {
     std::function<void(const std::string& message)> onMessage_callback_;
 
     /// Exponential backoff interval for re-connect
-    uint32_t connection_backoff_s_ { CONNECTION_BACKOFF_S };
+    uint32_t connection_backoff_ms_ { CONNECTION_BACKOFF_MS };
 
     /// Keep track of connection timings
     ConnectionTimings connection_timings_;


### PR DESCRIPTION
Here we adjust the reconnect delay with a random interval between -500
and 500 milliseconds. This will give us some grace when a broker goes
down, since all clients will no longer attempt to reconnect at exactly
the same time.

As a side effect all durations in Connection have been changed to
milliseconds from microseconds and seconds. Changing the reconnect sleep
to miliseconds gives us more precision, and changing the rest keeps
everything uniform.