### PR TITLE
(PCP-53) Port cpp-pcp-client to boost::thread

### DIFF
--- a/lib/inc/cpp-pcp-client/connector/connection.hpp
+++ b/lib/inc/cpp-pcp-client/connector/connection.hpp
@@ -3,11 +3,11 @@
 
 #include <cpp-pcp-client/connector/timings.hpp>
 #include <cpp-pcp-client/connector/client_metadata.hpp>
+#include <cpp-pcp-client/util/thread.hpp>
 
 #include <string>
 #include <vector>
 #include <memory>
-#include <thread>
 #include <atomic>
 #include <stdint.h>
 
@@ -164,7 +164,7 @@ class Connection {
     std::unique_ptr<WS_Client_Type> endpoint_;
 
     /// Transport layer event loop thread
-    std::shared_ptr<std::thread> endpoint_thread_;
+    std::shared_ptr<Util::thread> endpoint_thread_;
 
     // Callback function called by the onOpen handler.
     std::function<void()> onOpen_callback;

--- a/lib/inc/cpp-pcp-client/connector/connector.hpp
+++ b/lib/inc/cpp-pcp-client/connector/connector.hpp
@@ -8,12 +8,11 @@
 #include <cpp-pcp-client/validator/schema.hpp>
 #include <cpp-pcp-client/protocol/chunks.hpp>
 #include <cpp-pcp-client/protocol/message.hpp>
+#include <cpp-pcp-client/util/thread.hpp>
 
 #include <memory>
 #include <string>
 #include <map>
-#include <thread>  // mutex
-#include <condition_variable>
 #include <atomic>
 
 namespace PCPClient {
@@ -170,8 +169,8 @@ class Connector {
     bool is_monitoring_;
 
     /// To manage the monitoring task
-    std::mutex mutex_;
-    std::condition_variable cond_var_;
+    Util::mutex mutex_;
+    Util::condition_variable cond_var_;
 
     /// Flag; set to true if the dtor has been called
     bool is_destructing_;

--- a/lib/inc/cpp-pcp-client/connector/timings.hpp
+++ b/lib/inc/cpp-pcp-client/connector/timings.hpp
@@ -1,7 +1,7 @@
 #ifndef CPP_PCP_CLIENT_SRC_CONNECTOR_TIMINGS_H_
 #define CPP_PCP_CLIENT_SRC_CONNECTOR_TIMINGS_H_
 
-#include <chrono>
+#include <boost/chrono/chrono.hpp>
 #include <string>
 
 namespace PCPClient {
@@ -12,13 +12,13 @@ namespace PCPClient {
 
 class ConnectionTimings {
   public:
-    using Duration_us = std::chrono::duration<int, std::micro>;
+    using Duration_us = boost::chrono::duration<int, boost::micro>;
 
-    std::chrono::high_resolution_clock::time_point start;
-    std::chrono::high_resolution_clock::time_point tcp_pre_init;
-    std::chrono::high_resolution_clock::time_point tcp_post_init;
-    std::chrono::high_resolution_clock::time_point open;
-    std::chrono::high_resolution_clock::time_point close;
+    boost::chrono::high_resolution_clock::time_point start;
+    boost::chrono::high_resolution_clock::time_point tcp_pre_init;
+    boost::chrono::high_resolution_clock::time_point tcp_post_init;
+    boost::chrono::high_resolution_clock::time_point open;
+    boost::chrono::high_resolution_clock::time_point close;
 
     bool connection_started { false };
     bool connection_failed { false };

--- a/lib/inc/cpp-pcp-client/util/chrono.hpp
+++ b/lib/inc/cpp-pcp-client/util/chrono.hpp
@@ -1,0 +1,20 @@
+#ifndef CPP_PCP_CLIENT_SRC_UTIL_CHRONO_HPP_
+#define CPP_PCP_CLIENT_SRC_UTIL_CHRONO_HPP_
+
+#include <boost/chrono/chrono.hpp>
+
+/* This header encapsulates our use of chrono. This exists to support the changes
+   that had to be made during PCP-53 where we were forced to switch from using
+   std::thread to boost::thread. This encapsulation means that we can swtich back
+   by changing boost::chrono to std::chrono.
+*/
+
+namespace PCPClient {
+namespace Util {
+
+namespace chrono = boost::chrono;
+
+}  // namespace Util
+}  // namespace PCPClient
+
+#endif  // CPP_PCP_CLIENT_SRC_UTIL_CHRONO_HPP_

--- a/lib/inc/cpp-pcp-client/util/thread.hpp
+++ b/lib/inc/cpp-pcp-client/util/thread.hpp
@@ -1,0 +1,30 @@
+#ifndef CPP_PCP_CLIENT_SRC_UTIL_THREAD_HPP_
+#define CPP_PCP_CLIENT_SRC_UTIL_THREAD_HPP_
+
+#include <boost/thread/thread.hpp>
+
+/* This header encapsulates our use of threads and locking structures.
+   During PCP-53 we were forced to switch from using std::thread to boost::thread.
+   This encapsulation means that we can swtich back by changing boost::thread, etc
+   to std::thread, etc here and leave the rest of the code untouched.
+*/
+
+namespace PCPClient {
+namespace Util {
+
+using thread = boost::thread;
+using mutex = boost::mutex;
+using condition_variable = boost::condition_variable;
+
+template <class T>
+using lock_guard = boost::lock_guard<T>;
+
+template <class T>
+using unique_lock = boost::unique_lock<T>;
+
+namespace this_thread = boost::this_thread;
+
+}  // namespace Util
+}  // namespace PCPClient
+
+#endif  // CPP_PCP_CLIENT_SRC_UTIL_THREAD_HPP_

--- a/lib/src/connector/timings.cc
+++ b/lib/src/connector/timings.cc
@@ -5,26 +5,26 @@
 namespace PCPClient {
 
 ConnectionTimings::ConnectionTimings()
-        : start { std::chrono::high_resolution_clock::now() } {
+        : start { boost::chrono::high_resolution_clock::now() } {
 }
 
 ConnectionTimings::Duration_us ConnectionTimings::getTCPInterval() const {
-    return std::chrono::duration_cast<ConnectionTimings::Duration_us>(
+    return boost::chrono::duration_cast<ConnectionTimings::Duration_us>(
         tcp_pre_init - start);
 }
 
 ConnectionTimings::Duration_us ConnectionTimings::getHandshakeInterval() const {
-    return std::chrono::duration_cast<ConnectionTimings::Duration_us>(
+    return boost::chrono::duration_cast<ConnectionTimings::Duration_us>(
         tcp_post_init - tcp_pre_init);
 }
 
 ConnectionTimings::Duration_us ConnectionTimings::getWebSocketInterval() const {
-    return std::chrono::duration_cast<ConnectionTimings::Duration_us>(
+    return boost::chrono::duration_cast<ConnectionTimings::Duration_us>(
         open - start);
 }
 
 ConnectionTimings::Duration_us ConnectionTimings::getCloseInterval() const {
-    return std::chrono::duration_cast<ConnectionTimings::Duration_us>(
+    return boost::chrono::duration_cast<ConnectionTimings::Duration_us>(
         close - start);
 }
 


### PR DESCRIPTION
Here we add two header files to encapsulate which threading, locking and
chrono libraries we use. Due to us not currently having working
std::thread available on AIX, we make the switch to boost::thread. In
the future we can switch back to using the standard libraries by
replacing boost:: with std:: in thread.hpp and chrono.hpp.