### PR TITLE
(maint) Fix compiling pxp-agent on Windows

### DIFF
--- a/lib/inc/cpp-pcp-client/util/thread.hpp
+++ b/lib/inc/cpp-pcp-client/util/thread.hpp
@@ -1,7 +1,10 @@
 #ifndef CPP_PCP_CLIENT_SRC_UTIL_THREAD_HPP_
 #define CPP_PCP_CLIENT_SRC_UTIL_THREAD_HPP_
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstrict-aliasing"
 #include <boost/thread/thread.hpp>
+#pragma GCC diagnostic pop
 
 /* This header encapsulates our use of threads and locking structures.
    During PCP-53 we were forced to switch from using std::thread to boost::thread.


### PR DESCRIPTION
Boost.Thread's shared_mutex implementation generates a strict-aliasing
warning on Windows with mingw. Suppress those warnings so we can compile.