### PR TITLE
(PCP-42) Add version_error schema

### DIFF
--- a/lib/inc/cpp-pcp-client/protocol/schemas.hpp
+++ b/lib/inc/cpp-pcp-client/protocol/schemas.hpp
@@ -41,6 +41,10 @@ Schema DestinationReportSchema();
 static const std::string TTL_EXPIRED_TYPE { "http://puppetlabs.com/ttl_expired" };
 Schema TTLExpiredSchema();
 
+// version error
+static const std::string VERSION_ERROR_TYPE { "http://puppetlabs.com/version_error" };
+Schema VersionErrorSchema();
+
 //
 // debug
 //

--- a/lib/src/protocol/schemas.cc
+++ b/lib/src/protocol/schemas.cc
@@ -61,6 +61,15 @@ Schema TTLExpiredSchema() {
     return schema;
 }
 
+Schema VersionErrorSchema() {
+    Schema schema { VERSION_ERROR_TYPE, ContentType::Json };
+    // NB: additionalProperties = false
+    schema.addConstraint("id", TypeConstraint::String, true);
+    schema.addConstraint("target", TypeConstraint::String, true);
+    schema.addConstraint("reason", TypeConstraint::String, true);
+    return schema;
+}
+
 Schema DebugSchema() {
     Schema schema { DEBUG_SCHEMA_NAME, ContentType::Json };
     schema.addConstraint("hops", TypeConstraint::Array, true);


### PR DESCRIPTION
Here we add the version_error schema as specified in pcp-specifications.