### PR TITLE
(PCP-68) Add logging config for cpp-pcp-client

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -16,6 +16,7 @@ set(SOURCES
     src/protocol/message.cc
     src/protocol/schemas.cc
     src/protocol/serialization.cc
+    src/util/logging.cc
     src/validator/schema.cc
     src/validator/validator.cc
 )

--- a/lib/inc/cpp-pcp-client/util/logging.hpp
+++ b/lib/inc/cpp-pcp-client/util/logging.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <ostream>
+
+/* This header provides a utility to setup logging for the cpp-pcp-client library.
+   When Boost.Log is statically linked, logging configuration has to be done from
+   within the cpp-pcp-client library for logging to work.
+*/
+
+namespace PCPClient {
+namespace Util {
+
+void setupLogging(std::ostream &stream, bool color, std::string const& level);
+
+}  // namespace Util
+}  // namespace PCPClient

--- a/lib/src/util/logging.cc
+++ b/lib/src/util/logging.cc
@@ -1,0 +1,30 @@
+#include <cpp-pcp-client/util/logging.hpp>
+#define LEATHERMAN_LOGGING_NAMESPACE "puppetlabs.pcp_client.configuration"
+#include <leatherman/logging/logging.hpp>
+#include <map>
+
+namespace PCPClient {
+namespace Util {
+
+namespace lth_log = leatherman::logging;
+
+void setupLogging(std::ostream &stream, bool color, std::string const& level)
+{
+    const std::map<std::string, lth_log::log_level> option_to_log_level {
+        { "none", lth_log::log_level::none },
+        { "trace", lth_log::log_level::trace },
+        { "debug", lth_log::log_level::debug },
+        { "info", lth_log::log_level::info },
+        { "warning", lth_log::log_level::warning },
+        { "error", lth_log::log_level::error },
+        { "fatal", lth_log::log_level::fatal }
+    };
+    auto lvl = option_to_log_level.at(level);
+
+    lth_log::setup_logging(stream);
+    lth_log::set_colorization(color);
+    lth_log::set_level(lvl);
+}
+
+}  // namespace Util
+}  // namespace PCPClient


### PR DESCRIPTION
Add a helper to configure logging for cpp-pcp-client.
Required when statically linking Boost.Log.