### PR TITLE
(PCP-67) Bump cmake requirement to 3.2.2, set CMAKE_INSTALL_RPATH

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,12 @@ set(ROOT_PATH ${PROJECT_SOURCE_DIR})
 configure_file(templates/root_path.hpp ${CMAKE_BINARY_DIR}/generated/root_path.hpp)
 include_directories(${CMAKE_BINARY_DIR}/generated)
 
+# Set RPATH if not installing to a system library directory
+list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX}/lib" INSTALL_IS_SYSTEM_DIR)
+if ("${INSTALL_IS_SYSTEM_DIR}" STREQUAL "-1")
+    set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+endif()
+
 # Set compiler flags
 include(cflags)
 set(CPP_PCP_CLIENT_FLAGS "-Wno-deprecated-declarations -Wno-reorder -Wno-sign-compare")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.2.2)
 project(cpp-pcp-client)
 
 # Project paths


### PR DESCRIPTION
Prior to this changeset, execution of pxp-agent on OS X fails with ```dyld: Library not loaded:
libcpp-pcp-client.so```. To fix this, we borrow from Facter, bumping the cmake requirement to 3.2.2 and setting the CMAKE_INSTALL_RPATH based on the install prefix.