### PR TITLE
(maint) Util::logging forces colorization instead of setting

### DIFF
--- a/lib/inc/cpp-pcp-client/util/logging.hpp
+++ b/lib/inc/cpp-pcp-client/util/logging.hpp
@@ -10,7 +10,9 @@
 namespace PCPClient {
 namespace Util {
 
-void setupLogging(std::ostream &stream, bool color, std::string const& level);
+void setupLogging(std::ostream &stream,
+                  bool force_colorization,
+                  std::string const& loglevel_label);
 
 }  // namespace Util
 }  // namespace PCPClient

--- a/lib/src/util/logging.cc
+++ b/lib/src/util/logging.cc
@@ -8,9 +8,10 @@ namespace Util {
 
 namespace lth_log = leatherman::logging;
 
-void setupLogging(std::ostream &stream, bool color, std::string const& level)
-{
-    const std::map<std::string, lth_log::log_level> option_to_log_level {
+void setupLogging(std::ostream &stream,
+                  bool force_colorization,
+                  std::string const& loglevel_label) {
+    const std::map<std::string, lth_log::log_level> label_to_log_level {
         { "none", lth_log::log_level::none },
         { "trace", lth_log::log_level::trace },
         { "debug", lth_log::log_level::debug },
@@ -19,11 +20,13 @@ void setupLogging(std::ostream &stream, bool color, std::string const& level)
         { "error", lth_log::log_level::error },
         { "fatal", lth_log::log_level::fatal }
     };
-    auto lvl = option_to_log_level.at(level);
 
+    auto lvl = label_to_log_level.at(loglevel_label);
     lth_log::setup_logging(stream);
-    lth_log::set_colorization(color);
     lth_log::set_level(lvl);
+    if (force_colorization) {
+        lth_log::set_colorization(true);
+    }
 }
 
 }  // namespace Util


### PR DESCRIPTION
By default, colorization should be set leatherman::logging, based on
the type of stream (console supports it, since it's based on shell
control sequences, whereas text streams don't). With this commit we call
leatherman's logging::set_colorization(true) only if the user code
wants to force this setting.