### PR TITLE
(maint) Use Leatherman defines

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ endif()
 include(cflags)
 set(CPP_PCP_CLIENT_FLAGS "-Wno-deprecated-declarations -Wno-reorder -Wno-sign-compare")
 set(CMAKE_CXX_FLAGS "${LEATHERMAN_CXX_FLAGS} ${CPP_PCP_CLIENT_FLAGS}")
+add_definitions(${LEATHERMAN_DEFINITIONS})
 
 # Leatherman it up
 include(options)


### PR DESCRIPTION
Leatherman provides defines that enforce Unicode on Windows and correct
handling of UTF-8 in Boost.Log. Use these definitions.