### PR TITLE
(PCP-125) Error in case fails to validate certs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ collection of abstractions which can be used to initiate connections to a PCP
 broker, wrapping the PCP message format and performing schema validation for
 message bodies.
 
+cpp-pcp-client implements PCP by layering it upon WebSocket; it uses
+[WebSocket++][websocket++] for that.
+
 A tutorial on how to create a PCP agent / controller pair with cpp-pcp-client is
 [here][tutorial].
 
@@ -463,3 +466,4 @@ Example usage:
 [tutorial]: https://github.com/puppetlabs/cpp-pcp-client/tree/master/tutorial
 [specs]: https://github.com/puppetlabs/pcp-specifications
 [json_container]: https://github.com/puppetlabs/leatherman/tree/master/json_container
+[websocket++]: http://www.zaphoyd.com/websocketpp/

--- a/lib/src/connector/connection.cc
+++ b/lib/src/connector/connection.cc
@@ -182,7 +182,6 @@ void Connection::connect(int max_connect_attempts) {
             continue;
 
         case(ConnectionStateValues::closed):
-            assert(previous_c_s != ConnectionStateValues::open);
             if (previous_c_s == ConnectionStateValues::closed) {
                 connect_();
                 Util::this_thread::sleep_for(

--- a/lib/src/connector/connection.cc
+++ b/lib/src/connector/connection.cc
@@ -292,7 +292,7 @@ void Connection::connect_() {
 //
 
 WS_Context_Ptr Connection::onTlsInit(WS_Connection_Handle hdl) {
-    LOG_TRACE("WebSocket TLS initialization event");
+    LOG_INFO("WebSocket TLS initialization event; about to validate the certificate");
     // NB: for TLS certificates, refer to:
     // www.boost.org/doc/libs/1_56_0/doc/html/boost_asio/reference/ssl__context.html
     WS_Context_Ptr ctx {

--- a/lib/src/connector/connection.cc
+++ b/lib/src/connector/connection.cc
@@ -162,7 +162,7 @@ void Connection::connect(int max_connect_attempts) {
             break;
 
         case(ConnectionStateValues::connecting):
-            previous_c_s = current_c_s;
+            previous_c_s = ConnectionStateValues::connecting;
             Util::this_thread::sleep_for(
                 Util::chrono::milliseconds(CONNECTION_MIN_INTERVAL));
             continue;
@@ -176,7 +176,7 @@ void Connection::connect(int max_connect_attempts) {
             return;
 
         case(ConnectionStateValues::closing):
-            previous_c_s = current_c_s;
+            previous_c_s = ConnectionStateValues::closing;
             Util::this_thread::sleep_for(
                 Util::chrono::milliseconds(CONNECTION_MIN_INTERVAL));
             continue;

--- a/lib/src/connector/connection.cc
+++ b/lib/src/connector/connection.cc
@@ -307,7 +307,8 @@ WS_Context_Ptr Connection::onTlsInit(WS_Connection_Handle hdl) {
                                   boost::asio::ssl::context::file_format::pem);
         ctx->load_verify_file(client_metadata_.ca);
     } catch (std::exception& e) {
-        LOG_ERROR("Failed to configure TLS: %1%", e.what());
+        throw connection_processing_error { std::string { "TLS error: " }
+                                            + e.what() };
     }
     return ctx;
 }

--- a/lib/src/connector/connection.cc
+++ b/lib/src/connector/connection.cc
@@ -169,8 +169,6 @@ void Connection::connect(int max_connect_attempts) {
 
         case(ConnectionStateValues::open):
             if (previous_c_s != ConnectionStateValues::open) {
-                LOG_INFO("Successfully established a WebSocket connection with "
-                         "the PCP broker");
                 connection_backoff_ms_ = CONNECTION_BACKOFF_MS;
             }
             return;

--- a/lib/src/connector/connection.cc
+++ b/lib/src/connector/connection.cc
@@ -358,7 +358,7 @@ void Connection::onOpen(WS_Connection_Handle hdl) {
     connection_timings_.open = Util::chrono::high_resolution_clock::now();
     connection_timings_.connection_started = true;
     LOG_DEBUG("WebSocket on open event - %1%", connection_timings_.toString());
-    LOG_INFO("WebSocket connection established");
+    LOG_INFO("Successfully established a WebSocket connection with the PCP broker");
     connection_state_ = ConnectionStateValues::open;
 
     if (onOpen_callback) {

--- a/lib/src/connector/connection.cc
+++ b/lib/src/connector/connection.cc
@@ -126,12 +126,14 @@ void Connection::resetCallbacks() {
 //
 
 void Connection::connect(int max_connect_attempts) {
-    // FSM: states are ConnectionStateValues; as for the transitions,
-    //      we assume that the connection_state_:
-    // - can be set to 'initialized' only by the Connection constructor;
-    // - is set to 'connecting' by connect_();
-    // - after a connect_() call, it will become, eventually, open or
-    //   closed.
+    // FSM
+    //  - states are ConnectionStateValues:
+    //      * initialized - connecting - open - closing - closed
+    //  - for the transitions, we assume that the connection_state_:
+    //      * can be set to 'initialized' only by the Connection constructor;
+    //      * is set to 'connecting' by connect_();
+    //      * after a connect_() call, it will become, eventually, open or
+    //        closed.
 
     ConnectionState previous_c_s = connection_state_.load();
     ConnectionState current_c_s;
@@ -155,12 +157,14 @@ void Connection::connect(int max_connect_attempts) {
         case(ConnectionStateValues::initialized):
             assert(previous_c_s == ConnectionStateValues::initialized);
             connect_();
-            Util::this_thread::sleep_for(Util::chrono::milliseconds(CONNECTION_MIN_INTERVAL));
+            Util::this_thread::sleep_for(
+                Util::chrono::milliseconds(CONNECTION_MIN_INTERVAL));
             break;
 
         case(ConnectionStateValues::connecting):
             previous_c_s = current_c_s;
-            Util::this_thread::sleep_for(Util::chrono::milliseconds(CONNECTION_MIN_INTERVAL));
+            Util::this_thread::sleep_for(
+                Util::chrono::milliseconds(CONNECTION_MIN_INTERVAL));
             continue;
 
         case(ConnectionStateValues::open):
@@ -173,14 +177,16 @@ void Connection::connect(int max_connect_attempts) {
 
         case(ConnectionStateValues::closing):
             previous_c_s = current_c_s;
-            Util::this_thread::sleep_for(Util::chrono::milliseconds(CONNECTION_MIN_INTERVAL));
+            Util::this_thread::sleep_for(
+                Util::chrono::milliseconds(CONNECTION_MIN_INTERVAL));
             continue;
 
         case(ConnectionStateValues::closed):
             assert(previous_c_s != ConnectionStateValues::open);
             if (previous_c_s == ConnectionStateValues::closed) {
                 connect_();
-                Util::this_thread::sleep_for(Util::chrono::milliseconds(CONNECTION_MIN_INTERVAL));
+                Util::this_thread::sleep_for(
+                    Util::chrono::milliseconds(CONNECTION_MIN_INTERVAL));
                 previous_c_s = ConnectionStateValues::connecting;
             } else {
                 LOG_WARNING("Failed to establish a WebSocket connection; "
@@ -188,9 +194,11 @@ void Connection::connect(int max_connect_attempts) {
                             static_cast<int>(connection_backoff_ms_ / 1000));
                 // Randomly adjust the interval slightly to help calm a
                 // thundering herd
-                Util::this_thread::sleep_for(Util::chrono::milliseconds(connection_backoff_ms_ + dist(engine)));
+                Util::this_thread::sleep_for(
+                    Util::chrono::milliseconds(connection_backoff_ms_ + dist(engine)));
                 connect_();
-                Util::this_thread::sleep_for(Util::chrono::milliseconds(CONNECTION_MIN_INTERVAL));
+                Util::this_thread::sleep_for(
+                    Util::chrono::milliseconds(CONNECTION_MIN_INTERVAL));
                 if (try_again && !got_max_backoff) {
                     connection_backoff_ms_ *= CONNECTION_BACKOFF_MULTIPLIER;
                 }


### PR DESCRIPTION
With this commit we prevent the agent from trying to establish a
WebSocket connection in case the provided TLS certs are not validated by
the boost asio context. This may happen in casse of a cert / key
mismatch or in case of an error when retrieving the password.

Improving log messages.
Improving connect() FSM.