### PR TITLE
(PCP-136) Use static libraries to resolve AIX linking issues, and don't use SYSTEM

### DIFF
--- a/ext/cpp-pcp-client.cmake
+++ b/ext/cpp-pcp-client.cmake
@@ -15,4 +15,4 @@ externalproject_add(
 )
 externalproject_get_property(cpp-pcp-client SOURCE_DIR)
 set(CPP_PCP_CLIENT_INCLUDE_DIRS "${SOURCE_DIR}/src")
-set(CPP_PCP_CLIENT_LIB "${SOURCE_DIR}/lib/libcpp-pcp-client.so")
+set(CPP_PCP_CLIENT_LIB "${SOURCE_DIR}/lib/libcpp-pcp-client.a")

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -21,30 +21,12 @@ set(SOURCES
     src/validator/validator.cc
 )
 
-set(LIBS
-    ${LEATHERMAN_LIBRARIES}
-    ${Boost_LIBRARIES}
-    ${OPENSSL_SSL_LIBRARY}
-    ${OPENSSL_CRYPTO_LIBRARY}
-    ${PTHREADS}
-)
+add_library(cpp-pcp-client STATIC ${SOURCES})
 
-if (WIN32)
-    set(LIBCPP_PCP_CLIENT_INSTALL_DESTINATION bin)
-    set (PLATFORM_LIBRARIES Ws2_32)
-else()
-    #   TODO: lib64 for certain operating systems?
-    set(LIBCPP_PCP_CLIENT_INSTALL_DESTINATION lib)
-endif()
-
-
-add_library(libcpp-pcp-client-src OBJECT ${SOURCES})
-set_target_properties(libcpp-pcp-client-src PROPERTIES POSITION_INDEPENDENT_CODE true)
-add_library(libcpp-pcp-client SHARED $<TARGET_OBJECTS:libcpp-pcp-client-src>)
-target_link_libraries(libcpp-pcp-client PRIVATE ${LIBS} ${PLATFORM_LIBRARIES})
-set_target_properties(libcpp-pcp-client  PROPERTIES PREFIX "" SUFFIX ".so" IMPORT_PREFIX "" IMPORT_SUFFIX ".so.a")
-
-install(TARGETS libcpp-pcp-client DESTINATION "${LIBCPP_PCP_CLIENT_INSTALL_DESTINATION}")
+install(TARGETS cpp-pcp-client
+    RUNTIME DESTINATION bin
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib)
 install(DIRECTORY inc/cpp-pcp-client DESTINATION include)
 
 add_subdirectory(tests)

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -24,7 +24,7 @@ find_package(Boost 1.54 REQUIRED
 
 include_directories(
     ${LEATHERMAN_CATCH_INCLUDE}
-    SYSTEM ${Boost_INCLUDE_DIRS}
+    ${Boost_INCLUDE_DIRS}
 )
 
 add_executable(${test_BIN} ${SOURCES})

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -28,10 +28,20 @@ include_directories(
 )
 
 add_executable(${test_BIN} ${SOURCES})
-target_link_libraries(${test_BIN} libcpp-pcp-client ${PLATFORM_LIBRARIES})
+target_link_libraries(${test_BIN} cpp-pcp-client ${PLATFORM_LIBRARIES})
+
+if (WIN32)
+    set(PLATFORM_LIBRARIES Ws2_32)
+endif()
 
 set(LIBS
+    cpp-pcp-client
+    ${LEATHERMAN_LIBRARIES}
     ${Boost_LIBRARIES}
+    ${OPENSSL_SSL_LIBRARY}
+    ${OPENSSL_CRYPTO_LIBRARY}
+    ${PTHREADS}
+    ${PLATFORM_LIBRARIES}
 )
 
 target_link_libraries(${test_BIN} ${LIBS})

--- a/lib/tests/unit/validator/schema_test.cc
+++ b/lib/tests/unit/validator/schema_test.cc
@@ -2,10 +2,14 @@
 
 #include <cpp-pcp-client/validator/schema.hpp>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wextra"
+#pragma GCC diagnostic ignored "-Wignored-qualifiers"
 #include <valijson/adapters/rapidjson_adapter.hpp>
 #include <valijson/schema_parser.hpp>
 #include <valijson/validation_results.hpp>
 #include <valijson/validator.hpp>
+#pragma GCC diagnostic pop
 
 namespace PCPClient {
 


### PR DESCRIPTION
##### Use static libraries to resolve AIX linking issues

AIX has a limit on shared library TOC size. Try static linking to avoid the issue.

##### Fix marking includes as SYSTEM

On AIX GCC assumes `-isystem` headers are all C, and will wrap them in `extern "C"`. We were misusing the SYSTEM tag for C++ header files. Stop doing that.