### PR TITLE
(PCP-136) Fix Solaris dependencies that were implicit

### DIFF
--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -32,6 +32,8 @@ target_link_libraries(${test_BIN} cpp-pcp-client ${PLATFORM_LIBRARIES})
 
 if (WIN32)
     set(PLATFORM_LIBRARIES Ws2_32)
+elseif ("${CMAKE_SYSTEM_NAME}" MATCHES "SunOS")
+    set(PLATFORM_LIBRARIES socket nsl)
 endif()
 
 set(LIBS


### PR DESCRIPTION
When we were building shared libraries, system libraries were being
included implicitly. Call them out explicitly now for unit tests.