### PR TITLE
(PCP-121) Explicitly export symbols, again

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -38,6 +38,17 @@ add_library(libcpp-pcp-client SHARED ${SOURCES})
 target_link_libraries(libcpp-pcp-client PRIVATE ${LIBS} ${PLATFORM_LIBS})
 set_target_properties(libcpp-pcp-client PROPERTIES PREFIX "" SUFFIX ".so" IMPORT_PREFIX "" IMPORT_SUFFIX ".so.a")
 
+# Generate the export header
+include(GenerateExportHeader)
+generate_export_header(libcpp-pcp-client EXPORT_FILE_NAME "${CMAKE_CURRENT_LIST_DIR}/inc/cpp-pcp-client/export.h")
+
+if (NOT APPLE)
+    add_compiler_export_flags()
+endif()
+if (WIN32)
+    add_definitions("-Dlibcpp_pcp_client_EXPORTS")
+endif()
+
 install(TARGETS libcpp-pcp-client
     RUNTIME DESTINATION bin
     LIBRARY DESTINATION lib

--- a/lib/inc/cpp-pcp-client/connector/client_metadata.hpp
+++ b/lib/inc/cpp-pcp-client/connector/client_metadata.hpp
@@ -1,15 +1,16 @@
 #ifndef CPP_PCP_CLIENT_SRC_CONNECTOR_CLIENT_METADATA_H_
 #define CPP_PCP_CLIENT_SRC_CONNECTOR_CLIENT_METADATA_H_
 
+#include <cpp-pcp-client/export.h>
 #include <string>
 
 namespace PCPClient {
 
-void validatePrivateKeyCertPair(const std::string& key, const std::string& crt);
+LIBCPP_PCP_CLIENT_EXPORT void validatePrivateKeyCertPair(const std::string& key, const std::string& crt);
 
-std::string getCommonNameFromCert(const std::string& crt);
+LIBCPP_PCP_CLIENT_EXPORT std::string getCommonNameFromCert(const std::string& crt);
 
-class ClientMetadata {
+class LIBCPP_PCP_CLIENT_EXPORT ClientMetadata {
   public:
     std::string ca;
     std::string crt;

--- a/lib/inc/cpp-pcp-client/connector/connection.hpp
+++ b/lib/inc/cpp-pcp-client/connector/connection.hpp
@@ -4,6 +4,7 @@
 #include <cpp-pcp-client/connector/timings.hpp>
 #include <cpp-pcp-client/connector/client_metadata.hpp>
 #include <cpp-pcp-client/util/thread.hpp>
+#include <cpp-pcp-client/export.h>
 
 #include <string>
 #include <vector>
@@ -90,7 +91,7 @@ using CloseCode = CloseCodeValues::value_;
 // Connection
 //
 
-class Connection {
+class LIBCPP_PCP_CLIENT_EXPORT Connection {
   public:
     /// The Connection class provides the necessary logic to establish
     /// and use a PCP connection over WebSocket.

--- a/lib/inc/cpp-pcp-client/connector/connector.hpp
+++ b/lib/inc/cpp-pcp-client/connector/connector.hpp
@@ -9,6 +9,7 @@
 #include <cpp-pcp-client/protocol/chunks.hpp>
 #include <cpp-pcp-client/protocol/message.hpp>
 #include <cpp-pcp-client/util/thread.hpp>
+#include <cpp-pcp-client/export.h>
 
 #include <memory>
 #include <string>
@@ -22,7 +23,7 @@ namespace PCPClient {
 //
 namespace lth_jc = leatherman::json_container;
 
-class Connector {
+class LIBCPP_PCP_CLIENT_EXPORT Connector {
   public:
     using MessageCallback = std::function<void(const ParsedChunks& parsed_chunks)>;
 

--- a/lib/inc/cpp-pcp-client/protocol/chunks.hpp
+++ b/lib/inc/cpp-pcp-client/protocol/chunks.hpp
@@ -3,6 +3,7 @@
 
 #include <cpp-pcp-client/protocol/serialization.hpp>
 #include <cpp-pcp-client/validator/schema.hpp>
+#include <cpp-pcp-client/export.h>
 
 #include <string>
 #include <stdint.h>  // uint8_t
@@ -34,7 +35,7 @@ namespace ChunkDescriptor {
 // MessageChunk
 //
 
-struct MessageChunk {
+struct LIBCPP_PCP_CLIENT_EXPORT MessageChunk {
     uint8_t descriptor;
     uint32_t size;  // [byte]
     std::string content;
@@ -56,7 +57,7 @@ struct MessageChunk {
 // ParsedChunks
 //
 
-struct ParsedChunks {
+struct LIBCPP_PCP_CLIENT_EXPORT ParsedChunks {
     // Envelope
     lth_jc::JsonContainer envelope;
 

--- a/lib/inc/cpp-pcp-client/protocol/errors.hpp
+++ b/lib/inc/cpp-pcp-client/protocol/errors.hpp
@@ -1,34 +1,35 @@
 #ifndef CPP_PCP_CLIENT_SRC_PROTOCOL_ERRORS_H_
 #define CPP_PCP_CLIENT_SRC_PROTOCOL_ERRORS_H_
 
+#include <cpp-pcp-client/export.h>
 #include <stdexcept>
 #include <string>
 
 namespace PCPClient {
 
 /// Base error class.
-class message_error : public std::runtime_error {
+class LIBCPP_PCP_CLIENT_EXPORT message_error : public std::runtime_error {
   public:
     explicit message_error(std::string const& msg)
             : std::runtime_error(msg) {}
 };
 
 /// Serialization error
-class message_serialization_error : public message_error {
+class LIBCPP_PCP_CLIENT_EXPORT message_serialization_error : public message_error {
   public:
     explicit message_serialization_error(std::string const& msg)
             : message_error(msg) {}
 };
 
 /// Unsupported version error
-class unsupported_version_error : public message_error {
+class LIBCPP_PCP_CLIENT_EXPORT unsupported_version_error : public message_error {
   public:
     explicit unsupported_version_error(std::string const& msg)
             : message_error(msg) {}
 };
 
 /// Invalid chunk error
-class invalid_chunk_error : public message_error {
+class LIBCPP_PCP_CLIENT_EXPORT invalid_chunk_error : public message_error {
   public:
     explicit invalid_chunk_error(std::string const& msg)
             : message_error(msg) {}

--- a/lib/inc/cpp-pcp-client/protocol/message.hpp
+++ b/lib/inc/cpp-pcp-client/protocol/message.hpp
@@ -5,6 +5,7 @@
 #include <cpp-pcp-client/protocol/errors.hpp>
 #include <cpp-pcp-client/protocol/serialization.hpp>
 #include <cpp-pcp-client/validator/validator.hpp>
+#include <cpp-pcp-client/export.h>
 
 #include <string>
 #include <vector>
@@ -18,7 +19,7 @@ namespace PCPClient {
 // Message
 //
 
-class Message {
+class LIBCPP_PCP_CLIENT_EXPORT Message {
   public:
     // The default ctor is deleted since, for the PCP protocol, a
     // valid message must have an envelope chunk (invariant)

--- a/lib/inc/cpp-pcp-client/protocol/schemas.hpp
+++ b/lib/inc/cpp-pcp-client/protocol/schemas.hpp
@@ -2,6 +2,7 @@
 #define CPP_PCP_CLIENT_SRC_PROTOCOL_SCHEMAS_H_
 
 #include <cpp-pcp-client/validator/schema.hpp>
+#include <cpp-pcp-client/export.h>
 
 namespace PCPClient {
 namespace Protocol {
@@ -21,7 +22,7 @@ Schema EnvelopeSchema();
 static const std::string ASSOCIATE_REQ_TYPE  { "http://puppetlabs.com/associate_request" };
 static const std::string ASSOCIATE_RESP_TYPE { "http://puppetlabs.com/associate_response" };
 // NB: associate requests don't have a data chunk
-Schema AssociateResponseSchema();
+LIBCPP_PCP_CLIENT_EXPORT Schema AssociateResponseSchema();
 
 // inventory
 static const std::string INVENTORY_REQ_TYPE  { "http://puppetlabs.com/inventory_request" };

--- a/lib/inc/cpp-pcp-client/protocol/serialization.hpp
+++ b/lib/inc/cpp-pcp-client/protocol/serialization.hpp
@@ -2,6 +2,7 @@
 #define CPP_PCP_CLIENT_SRC_PROTOCOL_SERIALIZATION_H_
 
 #include <cpp-pcp-client/protocol/errors.hpp>
+#include <cpp-pcp-client/export.h>
 
 #include <boost/detail/endian.hpp>
 
@@ -25,8 +26,8 @@ typedef std::vector<uint8_t> SerializedMessage;
 
 #ifdef BOOST_LITTLE_ENDIAN
 
-uint32_t getNetworkNumber(const uint32_t& number);
-uint32_t getHostNumber(const uint32_t& number);
+LIBCPP_PCP_CLIENT_EXPORT uint32_t getNetworkNumber(const uint32_t& number);
+LIBCPP_PCP_CLIENT_EXPORT uint32_t getHostNumber(const uint32_t& number);
 
 #else  // we're using big endian (!)
 

--- a/lib/inc/cpp-pcp-client/util/logging.hpp
+++ b/lib/inc/cpp-pcp-client/util/logging.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cpp-pcp-client/export.h>
 #include <ostream>
 
 /* This header provides a utility to setup logging for the cpp-pcp-client library.
@@ -10,7 +11,7 @@
 namespace PCPClient {
 namespace Util {
 
-void setupLogging(std::ostream &stream,
+LIBCPP_PCP_CLIENT_EXPORT void setupLogging(std::ostream &stream,
                   bool force_colorization,
                   std::string const& loglevel_label);
 

--- a/lib/inc/cpp-pcp-client/validator/schema.hpp
+++ b/lib/inc/cpp-pcp-client/validator/schema.hpp
@@ -2,6 +2,7 @@
 #define CPP_PCP_CLIENT_SRC_VALIDATOR_SCHEMA_H_
 
 #include <leatherman/json_container/json_container.hpp>
+#include <cpp-pcp-client/export.h>
 
 #include <map>
 #include <string>
@@ -38,13 +39,13 @@ namespace lth_jc = leatherman::json_container;
 enum class TypeConstraint { Object, Array, String, Int, Bool, Double, Null, Any };
 enum class ContentType { Json, Binary };
 
-class schema_error : public std::runtime_error  {
+class LIBCPP_PCP_CLIENT_EXPORT schema_error : public std::runtime_error  {
   public:
     explicit schema_error(std::string const& msg)
             : std::runtime_error(msg) {}
 };
 
-class Schema {
+class LIBCPP_PCP_CLIENT_EXPORT Schema {
   public:
     Schema() = delete;
 

--- a/lib/inc/cpp-pcp-client/validator/validator.hpp
+++ b/lib/inc/cpp-pcp-client/validator/validator.hpp
@@ -3,6 +3,7 @@
 
 #include <cpp-pcp-client/validator/schema.hpp>
 #include <cpp-pcp-client/util/thread.hpp>
+#include <cpp-pcp-client/export.h>
 
 #include <map>
 
@@ -13,25 +14,25 @@ namespace PCPClient {
 //
 
 /// General validator error
-class validator_error : public std::runtime_error  {
+class LIBCPP_PCP_CLIENT_EXPORT validator_error : public std::runtime_error  {
   public:
     explicit validator_error(std::string const& msg)
         : std::runtime_error(msg) {}
 };
 
-class schema_redefinition_error : public validator_error  {
+class LIBCPP_PCP_CLIENT_EXPORT schema_redefinition_error : public validator_error  {
   public:
     explicit schema_redefinition_error(std::string const& msg)
         : validator_error(msg) {}
 };
 
-class schema_not_found_error : public validator_error  {
+class LIBCPP_PCP_CLIENT_EXPORT schema_not_found_error : public validator_error  {
   public:
     explicit schema_not_found_error(std::string const& msg)
         : validator_error(msg) {}
 };
 
-class validation_error : public validator_error {
+class LIBCPP_PCP_CLIENT_EXPORT validation_error : public validator_error {
   public:
     explicit validation_error(std::string const& msg)
         : validator_error(msg) {}
@@ -43,7 +44,7 @@ class validation_error : public validator_error {
 
 namespace lth_jc = leatherman::json_container;
 
-class Validator {
+class LIBCPP_PCP_CLIENT_EXPORT Validator {
   public:
     Validator();
 


### PR DESCRIPTION
This reverts commit 5c0a1c887537cd501a348d6c4afd5ca4b4388f48.

I suggest we hold off on this until after the 1st release.