### PR TITLE
(maint) Update cmake URL but ignore certificate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_install:
   # Use a predefined install location; cppcheck requires the cfg location is defined at compile-time.
   - mkdir -p $USERDIR
   # grab a pre-built cmake 3.2.3
-  - wget http://www.cmake.org/files/v3.2/cmake-3.2.3-Linux-x86_64.tar.gz
+  - wget --no-check-certificate https://cmake.org/files/v3.2/cmake-3.2.3-Linux-x86_64.tar.gz
   - tar xzvf cmake-3.2.3-Linux-x86_64.tar.gz --strip 1 -C $USERDIR
 
 script:


### PR DESCRIPTION
cmake.org updated to redirect to HTTPS and use a shorter URL.
However the certificate they use requires validation from an SSL
chain that's not installed on Ubuntu 12.04. Since we were previously
using HTTP, just ignore the certificate for now while this is
resolved.