### PR TITLE
(maint) Add overload of Util::logging::setupLogging

### DIFF
--- a/lib/inc/cpp-pcp-client/util/logging.hpp
+++ b/lib/inc/cpp-pcp-client/util/logging.hpp
@@ -1,7 +1,15 @@
 #pragma once
 
 #include <cpp-pcp-client/export.h>
+
 #include <ostream>
+
+// Forward declaration for leatherman::logging::log_level
+namespace leatherman {
+    namespace logging {
+        enum class log_level;
+    }  // namespace leatherman
+}  // namespace logging
 
 /* This header provides a utility to setup logging for the cpp-pcp-client library.
    When Boost.Log is statically linked, logging configuration has to be done from
@@ -11,9 +19,15 @@
 namespace PCPClient {
 namespace Util {
 
-LIBCPP_PCP_CLIENT_EXPORT void setupLogging(std::ostream &stream,
+LIBCPP_PCP_CLIENT_EXPORT
+void setupLogging(std::ostream &stream,
                   bool force_colorization,
                   std::string const& loglevel_label);
+
+LIBCPP_PCP_CLIENT_EXPORT
+void setupLogging(std::ostream &stream,
+                  bool force_colorization,
+                  leatherman::logging::log_level const& lvl);
 
 }  // namespace Util
 }  // namespace PCPClient

--- a/lib/src/util/logging.cc
+++ b/lib/src/util/logging.cc
@@ -1,12 +1,24 @@
 #include <cpp-pcp-client/util/logging.hpp>
+
 #define LEATHERMAN_LOGGING_NAMESPACE "puppetlabs.pcp_client.configuration"
 #include <leatherman/logging/logging.hpp>
+
 #include <map>
 
 namespace PCPClient {
 namespace Util {
 
 namespace lth_log = leatherman::logging;
+
+static void setupLoggingImp(std::ostream &stream,
+                            bool force_colorization,
+                            lth_log::log_level const& lvl) {
+    lth_log::setup_logging(stream);
+    lth_log::set_level(lvl);
+    if (force_colorization) {
+        lth_log::set_colorization(true);
+    }
+}
 
 void setupLogging(std::ostream &stream,
                   bool force_colorization,
@@ -22,11 +34,13 @@ void setupLogging(std::ostream &stream,
     };
 
     auto lvl = label_to_log_level.at(loglevel_label);
-    lth_log::setup_logging(stream);
-    lth_log::set_level(lvl);
-    if (force_colorization) {
-        lth_log::set_colorization(true);
-    }
+    setupLoggingImp(stream, force_colorization, lvl);
+}
+
+void setupLogging(std::ostream &stream,
+                  bool force_colorization,
+                  lth_log::log_level const& lvl) {
+    setupLoggingImp(stream, force_colorization, lvl);
 }
 
 }  // namespace Util


### PR DESCRIPTION
Adding an overload of the above function that receives a leatherman's
log_level value instead of a string one.