### PR TITLE
(PCP-137) Default to Release build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,11 @@ else ()
    set(CPP_PCP_CLIENT_TOPLEVEL FALSE)
 endif ()
 
+if (NOT CMAKE_BUILD_TYPE)
+    message(STATUS "Defaulting to a release build.")
+    set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel." FORCE)
+endif()
+
 add_definitions(-DCPP_PCP_CLIENT_LOGGING_PREFIX="puppetlabs.cpp_pcp_client")
 
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/vendor/leatherman/cmake")


### PR DESCRIPTION
In the past we defaulted CMAKE_BUILD_TYPE to empty. Here we update the
top level CMakeLists.txt to default to Release.