### PR TITLE
(maint) Ignore -Wunused-variable in Boost.Asio

### DIFF
--- a/lib/src/connector/connection.cc
+++ b/lib/src/connector/connection.cc
@@ -13,9 +13,12 @@
 #include <cpp-pcp-client/util/thread.hpp>
 #include <cpp-pcp-client/util/chrono.hpp>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-variable"
 #include <websocketpp/common/connection_hdl.hpp>
 #include <websocketpp/client.hpp>
 #include <websocketpp/config/asio_client.hpp>
+#pragma GCC diagnostic pop
 
 #define LEATHERMAN_LOGGING_NAMESPACE CPP_PCP_CLIENT_LOGGING_PREFIX".connection"
 


### PR DESCRIPTION
Boost.Asio copied functionality from Boost.System's error_code, but
doesn't copy it in providing a flag to skip it like
BOOST_SYSTEM_NO_DEPRECATED. So ignore unused-variable warnings generated
by Boost.Asio headers.

Due to bug #53431 in GCC 5.2, the warnings will still print, but won't
stop compilation. This may cause issues for AppVeyor when we update GCC.