### PR TITLE
(PCP-217) Connector::send() returns id when creating msg

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,8 +343,8 @@ or you can assign one callback to a lot of different schemas,
 ### Sending Messages
 
 Once you have established a connection to the PCP broker you can send messages
-using the _send_ function. There are two overloads for the function that are
-defined as:
+using the _send_ method. There are two main overloads for this function that
+are defined as (please check connector.hpp for the other overloads):
 
 ```
     void send(std::vector<std::string> targets,
@@ -359,26 +359,29 @@ With the parameters are described as follows:
 
  - targets - A vector of the destinations the message will be sent to
  - data_schema - The Schema that identifies the message type
- - timeout - Duration the message will be valid on the fabric
+ - timeout - Duration the message will be valid on the fabric, in seconds
  - data_json - A JsonContainer representing the data chunk of the message
  - debug - A vector of strings representing the debug chunks of the message (defaults to empty)
 
 
 ```
-    void send(std::vector<std::string> targets,
-              std::string data_schema,
-              unsigned int timeout,
-              std::string data_binary,
-              std::vector<JsonContainer> debug = std::vector<JsonContainer> {})
-                        throws (connection_processing_error, connection_not_init_error)
+    std::string send(std::vector<std::string> targets,
+                     std::string data_schema,
+                     unsigned int timeout,
+                     bool destination_report,
+                     std::string data_binary,
+                     std::vector<JsonContainer> debug = std::vector<JsonContainer> {})
+                              throws (connection_processing_error, connection_not_init_error)
 
 ```
 
-With the parameters are described as follows:
+The above overload returns the ID of the sent message and accepts the following
+parameters:
 
  - targets - A vector of the destinations the message will be sent to
  - data_schema - The Schema that identifies the message type
- - timeout - Duration the message will be valid on the fabric
+ - timeout - Duration the message will be valid on the fabric, in seconds
+ - destination_report - A boolean indicating whether or not requesting a destination report
  - data_binary - A string representing the data chunk of the message
  - debug - A vector of strings representing the debug chunks of the message (defaults to empty)
 
@@ -404,7 +407,8 @@ Example usage:
     JsonContainer data {};
     data.set<std::string>("foo", "bar");
     try {
-      connector.send({"pcp://*/potato"}, "potato_schema", 42, data);
+      auto id = connector.send({"pcp://*/potato"}, "potato_schema", 42, data);
+      std::cout << "Sent potato message to all potato clients, with ID=" << id << std::endl;
     } catch (connection_not_init_error e) {
       std::cout << "Cannot send message without being connected to the broker" << std::endl;
     } catch (connection_processing_error e) {

--- a/lib/inc/cpp-pcp-client/connector/connector.hpp
+++ b/lib/inc/cpp-pcp-client/connector/connector.hpp
@@ -18,10 +18,11 @@
 
 namespace PCPClient {
 
+namespace lth_jc = leatherman::json_container;
+
 //
 // Connector
 //
-namespace lth_jc = leatherman::json_container;
 
 class LIBCPP_PCP_CLIENT_EXPORT Connector {
   public:
@@ -104,8 +105,15 @@ class LIBCPP_PCP_CLIENT_EXPORT Connector {
     void monitorConnection(int max_connect_attempts = 0);
 
     /// Send the specified message.
+    /// Throw a connection_processing_error in case of failure;
+    /// throw a connection_not_init_error in case the connection
+    /// has not been opened previously.
+    void send(const Message& msg);
+
+    /// send() overloads that create and send a message as specified.
+    /// Return the ID of the message, as a string.
     ///
-    /// Other overloads may specify:
+    /// The caller may specify:
     ///   - targets: list of PCP URI strings
     ///   - message_type: schema name that identifies the message type
     ///   - timeout: expires entry in seconds
@@ -117,36 +125,34 @@ class LIBCPP_PCP_CLIENT_EXPORT Connector {
     ///   - throw a connection_processing_error in case of failure;
     ///   - throw a connection_not_init_error in case the connection
     ///     has not been opened previously.
-    void send(const Message& msg);
-
-    void send(const std::vector<std::string>& targets,
-              const std::string& message_type,
-              unsigned int timeout,
-              const lth_jc::JsonContainer& data_json,
-              const std::vector<lth_jc::JsonContainer>& debug
+    std::string send(const std::vector<std::string>& targets,
+                     const std::string& message_type,
+                     unsigned int timeout,
+                     const lth_jc::JsonContainer& data_json,
+                     const std::vector<lth_jc::JsonContainer>& debug
                         = std::vector<lth_jc::JsonContainer> {});
 
-    void send(const std::vector<std::string>& targets,
-              const std::string& message_type,
-              unsigned int timeout,
-              const std::string& data_binary,
-              const std::vector<lth_jc::JsonContainer>& debug
+    std::string send(const std::vector<std::string>& targets,
+                     const std::string& message_type,
+                     unsigned int timeout,
+                     const std::string& data_binary,
+                     const std::vector<lth_jc::JsonContainer>& debug
                         = std::vector<lth_jc::JsonContainer> {});
 
-    void send(const std::vector<std::string>& targets,
-              const std::string& message_type,
-              unsigned int timeout,
-              bool destination_report,
-              const lth_jc::JsonContainer& data_json,
-              const std::vector<lth_jc::JsonContainer>& debug
+    std::string send(const std::vector<std::string>& targets,
+                     const std::string& message_type,
+                     unsigned int timeout,
+                     bool destination_report,
+                     const lth_jc::JsonContainer& data_json,
+                     const std::vector<lth_jc::JsonContainer>& debug
                         = std::vector<lth_jc::JsonContainer> {});
 
-    void send(const std::vector<std::string>& targets,
-              const std::string& message_type,
-              unsigned int timeout,
-              bool destination_report,
-              const std::string& data_binary,
-              const std::vector<lth_jc::JsonContainer>& debug
+    std::string send(const std::vector<std::string>& targets,
+                     const std::string& message_type,
+                     unsigned int timeout,
+                     bool destination_report,
+                     const std::string& data_binary,
+                     const std::vector<lth_jc::JsonContainer>& debug
                         = std::vector<lth_jc::JsonContainer> {});
 
   private:
@@ -191,14 +197,15 @@ class LIBCPP_PCP_CLIENT_EXPORT Connector {
     MessageChunk createEnvelope(const std::vector<std::string>& targets,
                                 const std::string& message_type,
                                 unsigned int timeout,
-                                bool destination_report);
+                                bool destination_report,
+                                std::string& msg_id);
 
-    void sendMessage(const std::vector<std::string>& targets,
-                     const std::string& message_type,
-                     unsigned int timeout,
-                     bool destination_report,
-                     const std::string& data_txt,
-                     const std::vector<lth_jc::JsonContainer>& debug);
+    std::string sendMessage(const std::vector<std::string>& targets,
+                            const std::string& message_type,
+                            unsigned int timeout,
+                            bool destination_report,
+                            const std::string& data_txt,
+                            const std::vector<lth_jc::JsonContainer>& debug);
 
     // WebSocket Callback for the Connection instance to be triggered
     // on an onOpen event.


### PR DESCRIPTION
The Connector::send() overloads that create that instantiate Message now
return the id of the created message as a string.

This change is useful to enable the user code to check the in-reply-to
envelope entry when processing response messages sent by a PCP broker.