### PR TITLE
(PCP-209) Unvendor and rely on installed leatherman

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "vendor/leatherman"]
-	path = vendor/leatherman
-	url = https://github.com/puppetlabs/leatherman

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ addons:
       - gcc-4.8
       - g++-4.8
       - libboost-filesystem1.55-dev
-      - libboost-program-options1.55-dev
       - libboost-regex1.55-dev
       - libboost-date-time1.55-dev
       - libboost-thread1.55-dev
@@ -21,11 +20,15 @@ addons:
       - libboost-random1.55-dev
 
 before_install:
-  # Use a predefined install location; cppcheck requires the cfg location is defined at compile-time.
+  # Use a predefined install location; cppcheck requires the cfg
+  # location is defined at compile-time.
   - mkdir -p $USERDIR
-  # grab a pre-built cmake 3.2.3
+  # Grab a pre-built cmake 3.2.3
   - wget --no-check-certificate https://cmake.org/files/v3.2/cmake-3.2.3-Linux-x86_64.tar.gz
   - tar xzvf cmake-3.2.3-Linux-x86_64.tar.gz --strip 1 -C $USERDIR
+  # Install cpp-pcp-client's dependencies
+  - wget https://github.com/puppetlabs/leatherman/releases/download/${LEATHERMAN_VERSION}/leatherman.tar.gz
+  - tar xzvf leatherman.tar.gz -C $USERDIR
 
 script:
   - ./.travis_target.sh
@@ -36,6 +39,7 @@ env:
     - PYTHONUSERBASE=$USERDIR
     - PATH=$USERDIR/bin:$PATH
     - LD_LIBRARY_PATH=$USERDIR/lib:$LD_LIBRARY_PATH
+    - LEATHERMAN_VERSION=0.3.5
   matrix:
     - TRAVIS_TARGET=CPPLINT
     - TRAVIS_TARGET=CPPCHECK
@@ -44,4 +48,3 @@ env:
 
 notifications:
   email: false
-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,9 +19,8 @@ if (NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel." FORCE)
 endif()
 
+# Set the macro for leatherman's logging namespace
 add_definitions(-DCPP_PCP_CLIENT_LOGGING_PREFIX="puppetlabs.cpp_pcp_client")
-
-list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/vendor/leatherman/cmake")
 
 # Defined further options
 option(DEV_LOG_RAW_MESSAGE "Enable logging serialized messages (development setting - avoid this on Windows)" OFF)
@@ -37,38 +36,28 @@ if ("${INSTALL_IS_SYSTEM_DIR}" STREQUAL "-1")
     set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
 endif()
 
-# Set compiler flags
-include(cflags)
-set(CPP_PCP_CLIENT_FLAGS "-Wno-deprecated-declarations -Wno-reorder -Wno-sign-compare")
-set(CMAKE_CXX_FLAGS "${LEATHERMAN_CXX_FLAGS} ${CPP_PCP_CLIENT_FLAGS}")
-add_definitions(${LEATHERMAN_DEFINITIONS})
+# Find libraries
+find_package(Leatherman REQUIRED
+  COMPONENTS locale nowide catch logging rapidjson json_container util)
+find_package(Boost 1.54 REQUIRED
+  COMPONENTS filesystem system date_time thread log regex random)
+find_package(OpenSSL REQUIRED)
 
 # Leatherman it up
 include(options)
-option(BOOST_STATIC "Use Boost's static libraries" OFF)
-set(LEATHERMAN_USE_LOCALE TRUE)
-set(LEATHERMAN_USE_NOWIDE TRUE)
-set(LEATHERMAN_USE_CATCH TRUE)
-set(LEATHERMAN_USE_LOGGING TRUE)
-set(LEATHERMAN_USE_RAPIDJSON TRUE)
-set(LEATHERMAN_USE_JSON_CONTAINER TRUE)
-set(LEATHERMAN_USE_UTIL TRUE)
+include(cflags)
 leatherman_logging_line_numbers()
-add_subdirectory("vendor/leatherman")
 
-# Include further option definitions
+# Set compiler flags
+set(CPP_PCP_CLIENT_FLAGS "-Wno-deprecated-declarations -Wno-reorder -Wno-sign-compare")
+set(CMAKE_CXX_FLAGS "${LEATHERMAN_CXX_FLAGS} ${CPP_PCP_CLIENT_FLAGS}")
+add_definitions(${LEATHERMAN_DEFINITIONS})
 
 if(DEV_LOG_RAW_MESSAGE)
     add_definitions(-DDEV_LOG_RAW_MESSAGE)
 endif()
 
-# Find libraries
-find_package(Boost 1.54 REQUIRED
-  COMPONENTS filesystem system date_time thread log regex random)
-
-find_package(OpenSSL REQUIRED)
-
-# prefer openssl from ports
+# Prefer openssl from ports
 if ("${CMAKE_SYSTEM_NAME}" MATCHES "Darwin")
     set(CMAKE_LIBRARY_PATH ${CMAKE_LIBRARY_PATH} /opt/local/lib)
     set(CMAKE_INCLUDE_PATH ${CMAKE_INCLUDE_PATH} /opt/local/include)
@@ -81,10 +70,17 @@ endif()
 include(${VENDOR_DIRECTORY}/websocketpp.cmake)
 include(${VENDOR_DIRECTORY}/valijson.cmake)
 
+# Display a summary of the features
+include(FeatureSummary)
+feature_summary(WHAT ALL)
+
 link_directories(
     ${Boost_LIBRARY_DIRS}
     ${OPENSSL_INCLUDE_DIR}
 )
+
+# Pull in helper macros for working with leatherman libraries
+include(leatherman)
 
 # Add src subdirectory
 add_subdirectory(lib)
@@ -105,5 +101,4 @@ if (CPP_PCP_CLIENT_TOPLEVEL)
 
     add_cppcheck_dirs("${PROJECT_SOURCE_DIR}/lib")
     enable_cppcheck()
-
 endif()

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A tutorial on how to create a PCP agent / controller pair with cpp-pcp-client is
  - gnumake
  - cmake (2.8.12 or newer)
  - boost (1.54 or newer)
+ - [leatherman][leatherman], installed as a standalone library (0.3.5 or newer)
 
 ### Build
 
@@ -475,3 +476,4 @@ Example usage:
 [specs]: https://github.com/puppetlabs/pcp-specifications
 [json_container]: https://github.com/puppetlabs/leatherman/tree/master/json_container
 [websocket++]: http://www.zaphoyd.com/websocketpp/
+[leatherman]: https://github.com/puppetlabs/leatherman

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,12 @@
-install:
-  - git submodule update --init --recursive
+environment:
+  LEATHERMAN_VERSION: 0.3.5
 
+install:
   - choco install -y mingw-w64 -Version 4.8.3 -source https://www.myget.org/F/puppetlabs
   - choco install -y cmake -Version 3.2.2 -source https://www.myget.org/F/puppetlabs
   - SET PATH=C:\tools\mingw64\bin;%PATH%
+  - ps: $env:PATH = $env:PATH.Replace("Git\bin", "Git\cmd")
+  - ps: $env:PATH = $env:PATH.Replace("Git\usr\bin", "Git\cmd")
 
   - ps: wget 'https://s3.amazonaws.com/kylo-pl-bucket/boost_1_58_0-x86_64_mingw-w64_4.8.3_win32_seh.7z' -OutFile "$pwd\boost.7z"
   - ps: 7z.exe x boost.7z -oC:\tools | FIND /V "ing  "
@@ -14,12 +17,14 @@ install:
   - SET OPENSSL_ROOT_DIR=C:\tools
   - SET PATH=C:\tools\bin;%PATH%
 
+  - ps: wget 'https://s3.amazonaws.com/kylo-pl-bucket/curl-7.42.1-x86_64_mingw-w64_4.8.3_win32_seh.7z' -OutFile "$pwd\curl-7.42.1-x86_64_mingw-w64_4.8.3_win32_seh.7z"
+  - ps: 7z.exe x "curl-7.42.1-x86_64_mingw-w64_4.8.3_win32_seh.7z" -oC:\tools | FIND /V "ing "
+
+  - ps: wget "https://github.com/puppetlabs/leatherman/releases/download/$env:LEATHERMAN_VERSION/leatherman.7z" -OutFile "$pwd\leatherman.7z"
+  - ps: 7z.exe x leatherman.7z -oC:\tools | FIND /V "ing "
+
 build_script:
-  - ps: mv "C:\Program Files\Git\usr\bin\sh.exe" "C:\Program Files\Git\usr\bin\shxx.exe"
-  - ps: mv "C:\Program Files\Git\bin\sh.exe" "C:\Program Files\Git\bin\shxx.exe"
-  - ps: cmake -G "MinGW Makefiles" -DBOOST_ROOT="C:\tools\boost_1_58_0-x86_64_mingw-w64_4.8.3_win32_seh" -DBOOST_STATIC=ON -DBOOST_NOWIDE_SKIP_TESTS=ON -Wno-dev .
-  - ps: mv "C:\Program Files\Git\usr\bin\shxx.exe" "C:\Program Files\Git\usr\bin\sh.exe"
-  - ps: mv "C:\Program Files\Git\bin\shxx.exe" "C:\Program Files\Git\bin\sh.exe"
+  - ps: cmake -G "MinGW Makefiles" -DBOOST_ROOT="C:\tools\boost_1_58_0-x86_64_mingw-w64_4.8.3_win32_seh" -DBOOST_STATIC=ON -DCURL_STATIC=ON -DCMAKE_PREFIX_PATH="C:\tools\leatherman;C:\tools\curl-7.42.1-x86_64_mingw-w64_4.8.3_win32_seh" -Wno-dev .
   - ps: mingw32-make install
 
 test_script:


### PR DESCRIPTION
Removing leatherman's git submodule. Updating CMake, Appveyor, and
Travis configuration scripts. Updating leatherman's dependency on
README.