### PR TITLE
(PCP-269) Add pthread building dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,10 @@ find_package(Leatherman REQUIRED
 find_package(Boost 1.54 REQUIRED
   COMPONENTS filesystem system date_time thread log regex random)
 find_package(OpenSSL REQUIRED)
+# TODO(ale): same fix as FACT-1338; remove it once LTH-81 is done.
+# date_time and regex need threads on some platforms, and find_package
+# Boost only includes pthreads if you require Boost.Thread component.
+find_package(Threads)
 
 # Leatherman it up
 include(options)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -21,11 +21,13 @@ set(SOURCES
     src/validator/validator.cc
 )
 
+# TODO(ale): remove Thread dependency after LTH-81 changes
 set(LIBS
     ${LEATHERMAN_LIBRARIES}
     ${Boost_LIBRARIES}
     ${OPENSSL_SSL_LIBRARY}
     ${OPENSSL_CRYPTO_LIBRARY}
+    ${CMAKE_THREAD_LIBS_INIT}
 )
 
 if (WIN32)

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -22,9 +22,11 @@ set(test_BIN cpp-pcp-client-unittests)
 find_package(Boost 1.54 REQUIRED
   COMPONENTS filesystem system date_time thread log regex random)
 
+# TODO(ale): remove Thread dependency after LTH-81 changes
 include_directories(
     ${LEATHERMAN_CATCH_INCLUDE}
     ${Boost_INCLUDE_DIRS}
+    ${CMAKE_THREAD_LIBS_INIT}
 )
 
 add_executable(${test_BIN} ${SOURCES})


### PR DESCRIPTION
Here we add the pthread dependency; it is needed for the linkage of
Boost's date_time (necessary for leatherman_util) in AIX.

This fix relates to [FACT-1338](https://tickets.puppetlabs.com/browse/FACT-1338) and should be removed after [LTH-81](https://tickets.puppetlabs.com/browse/LTH-81).