### PR TITLE
(PCP-269) Add dependency to external projects to CMakeLists

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -37,6 +37,11 @@ elseif ("${CMAKE_SYSTEM_NAME}" MATCHES "SunOS")
 endif()
 
 add_library(libcpp-pcp-client SHARED ${SOURCES})
+
+# Explicit dependency on external projects to ensure they get
+# extracted when building with multiple jobs
+add_dependencies(libcpp-pcp-client websocketpp valijson)
+
 target_link_libraries(libcpp-pcp-client PRIVATE ${LIBS} ${PLATFORM_LIBS})
 set_target_properties(libcpp-pcp-client PROPERTIES PREFIX "" SUFFIX ".so" IMPORT_PREFIX "" IMPORT_SUFFIX ".so.a")
 


### PR DESCRIPTION
Making an explicit dependency on external projects (websocketpp and
valijson) in order to ensure that they get extracted before
cpp-pcp-client compilation starts, when building with multiple jobs.