### PR TITLE
(maint) Remove unnecessary pause from Connection test

### DIFF
--- a/lib/tests/main.cc
+++ b/lib/tests/main.cc
@@ -4,13 +4,18 @@
 
 #include "test.hpp"
 
+// To enable log messages:
+// #define ENABLE_LOGGING
+
+#ifdef ENABLE_LOGGING
 #define LEATHERMAN_LOGGING_NAMESPACE "puppetlabs.cpp_pcp_client.test"
 #include <leatherman/logging/logging.hpp>
+#endif
 
 int main(int argc, char* const argv[]) {
-    // set logging level to fatal
-    leatherman::logging::setup_logging(std::cout);
-    leatherman::logging::set_level(leatherman::logging::log_level::fatal);
+#ifdef ENABLE_LOGGING
+    leatherman::logging::set_level(leatherman::logging::log_level::debug);
+#endif
 
     // configure the Catch session and start it
     Catch::Session test_session;

--- a/lib/tests/unit/connector/connection_test.cc
+++ b/lib/tests/unit/connector/connection_test.cc
@@ -11,7 +11,8 @@ TEST_CASE("Connection::connect", "[connector]") {
     SECTION("throws a connection_processing_error if the broker url is "
             "not a valid WebSocket url") {
         ClientMetadata c_m { "test_client", getCaPath(), getCertPath(),
-                             getKeyPath(), 5000 };
+                             getKeyPath(), 6 };
+        // NB: the dtor will wait for the 6 ms specified above
         Connection connection { "foo", c_m };
 
         REQUIRE_THROWS_AS(connection.connect(),


### PR DESCRIPTION
An unit test for the Connection class used to pause for 5 s due to the
cleanup() method being invoked by default; this commit reduces such
pause to 6 ms.

Also we introduce a macro to enable logging for unit tests, as done in
pxp-agent.