### PR TITLE
(PCP-338) New logic for Associate Session

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -11,6 +11,7 @@ set(SOURCES
     src/connector/client_metadata.cc
     src/connector/connection.cc
     src/connector/connector.cc
+    src/connector/session_association.cc
     src/connector/timings.cc
     src/protocol/chunks.cc
     src/protocol/message.cc

--- a/lib/inc/cpp-pcp-client/connector/connector.hpp
+++ b/lib/inc/cpp-pcp-client/connector/connector.hpp
@@ -3,6 +3,7 @@
 
 #include <cpp-pcp-client/connector/connection.hpp>
 #include <cpp-pcp-client/connector/client_metadata.hpp>
+#include <cpp-pcp-client/connector/session_association.hpp>
 #include <cpp-pcp-client/connector/errors.hpp>
 #include <cpp-pcp-client/validator/validator.hpp>
 #include <cpp-pcp-client/validator/schema.hpp>
@@ -14,7 +15,6 @@
 #include <memory>
 #include <string>
 #include <map>
-#include <atomic>
 
 namespace PCPClient {
 
@@ -56,21 +56,43 @@ class LIBCPP_PCP_CLIENT_EXPORT Connector {
     /// Set an optional callback for associate responses
     void setAssociateCallback(MessageCallback callback);
 
+    /// Open the WebSocket connection and perform Session Association
+    ///
     /// Check the state of the underlying connection (WebSocket); in
-    /// case it's not open, try to re-open it.
-    /// Try to reopen for max_connect_attempts times or idefinetely,
-    /// in case that parameter is 0 (as by default). This is done by
-    /// following an exponential backoff.
-    /// Once the underlying connection is open, send an associate
-    /// session request to the broker.
+    /// case it's 'open' or 'connecting', close it. Then open it and
+    /// perform the PCP Session Association.
+    /// Try to (re)open for max_connect_attempts times or
+    /// indefinitely, in case that parameter is 0 (as by default).
+    /// This is done by following an exponential backoff.
+    /// Once the underlying connection is open, send an Associate
+    /// Session request to the broker (asynchronously; done by the
+    /// onOpen handler). Wait until an Associate Session response is
+    /// received and process it; a timeout will be used for that - see
+    /// error section below. In the meantime, consider any invalid
+    /// message received as a possible corrupted Associate Session
+    /// response. Also, consider possible PCP Error messages.
+    ///
     /// Throw a connection_config_error if it fails to set up the
     /// underlying communications layer (ex. invalid certificates).
+    ///
     /// Throw a connection_fatal_error if it fails to open the
     /// underlying connection after the specified number of attempts
-    /// or if it fails to send the associate session request.
-    /// NB: the function does not wait for the associate response; it
-    ///     returns right after sending the associate request
-    /// NB: the function is not thread safe
+    /// (ex. the specified broker is down).
+    ///
+    /// Throw a connection_association_error if:
+    ///  - an invalid message is received;
+    ///  - a PCP Error message is received, related to the current
+    ///    Associate Session request (matching done by message ID);
+    ///  - an Associate Session response is not received after a time
+    ///    interval equal to the ping period of monitorConnection()
+    ///    (15 s) after sending the Associate Session request.
+    ///
+    /// Throw a connection_association_response_failure if the
+    /// received associate session response does not indicate a
+    /// success.
+    ///
+    /// NB: this function is not thread safe; it should not be called
+    ///     when the monitor thread is executing
     void connect(int max_connect_attempts = 0);
 
     /// Returns true if the underlying connection is currently open,
@@ -177,20 +199,18 @@ class LIBCPP_PCP_CLIENT_EXPORT Connector {
     /// Associate response callback
     MessageCallback associate_response_callback_;
 
+    /// Flag; set to true if the dtor has been called
+    bool is_destructing_;
+
     /// Flag; true if monitorConnection is executing
     bool is_monitoring_;
 
     /// To manage the monitoring task
-    Util::mutex mutex_;
-    Util::condition_variable cond_var_;
+    Util::mutex monitor_mutex_;
+    Util::condition_variable monitor_cond_var_;
 
-    /// Flag; set to true if the dtor has been called
-    bool is_destructing_;
-
-    /// Flag; set to true when a successful associate response is
-    /// received, set to false by the ctor or when the underlying
-    /// connection drops.
-    std::atomic<bool> is_associated_;
+    /// To manage the Associate Session process
+    SessionAssociation session_association_;
 
     void checkConnectionInitialization();
 

--- a/lib/inc/cpp-pcp-client/connector/errors.hpp
+++ b/lib/inc/cpp-pcp-client/connector/errors.hpp
@@ -41,6 +41,22 @@ class connection_not_init_error : public connection_error {
             : connection_error(msg) {}
 };
 
+/// Connection error due to a timeout or a corrupted message during a
+/// session association exchange.
+class connection_association_error : public connection_error {
+  public:
+    explicit connection_association_error(std::string const& msg)
+            : connection_error(msg) {}
+};
+
+/// Connection error due to a Session Association response message
+/// that reports a failure.
+class connection_association_response_failure : public connection_error {
+  public:
+    explicit connection_association_response_failure(std::string const& msg)
+            : connection_error(msg) {}
+};
+
 }  // namespace PCPClient
 
 #endif  // CPP_PCP_CLIENT_SRC_CONNECTOR_ERRORS_H_

--- a/lib/inc/cpp-pcp-client/connector/session_association.hpp
+++ b/lib/inc/cpp-pcp-client/connector/session_association.hpp
@@ -1,0 +1,33 @@
+#ifndef CPP_PCP_CLIENT_SRC_CONNECTOR_SESSION_ASSOCIATION_HPP_
+#define CPP_PCP_CLIENT_SRC_CONNECTOR_SESSION_ASSOCIATION_HPP_
+
+#include <cpp-pcp-client/util/thread.hpp>
+#include <cpp-pcp-client/export.h>
+
+#include <string>
+#include <atomic>
+
+namespace PCPClient {
+
+// Encapsulates concurrency things for managing the state of the
+// Associate Session process; consumer code may want to hold a lock
+// over the instance mutex, depending on the usage
+
+struct LIBCPP_PCP_CLIENT_EXPORT SessionAssociation {
+    std::atomic<bool> success;
+    std::atomic<bool> in_progress;
+    std::atomic<bool> got_messaging_failure;
+    std::string request_id;
+    std::string error;
+    Util::mutex mtx;
+    Util::condition_variable cond_var;
+
+    SessionAssociation();
+
+    // Does not lock mtx
+    void reset();
+};
+
+}  // namespace PCPClient
+
+#endif  // CPP_PCP_CLIENT_SRC_CONNECTOR_SESSION_ASSOCIATION_HPP_

--- a/lib/src/connector/connection.cc
+++ b/lib/src/connector/connection.cc
@@ -57,7 +57,8 @@ Connection::Connection(const std::string& broker_ws_uri,
           client_metadata_ { client_metadata },
           connection_state_ { ConnectionStateValues::initialized },
           consecutive_pong_timeouts_ { 0 },
-          endpoint_ { new WS_Client_Type() }{
+          endpoint_ { new WS_Client_Type() }
+{
     // Turn off websocketpp logging to avoid runtime errors (see CTH-69)
     endpoint_->clear_access_channels(websocketpp::log::alevel::all);
     endpoint_->clear_error_channels(websocketpp::log::elevel::all);
@@ -323,27 +324,25 @@ void Connection::connect_() {
 //
 
 template <typename Verifier>
-class verbose_verification
-{
-public:
-  verbose_verification(Verifier verifier)
-    : verifier_(verifier)
-  {}
+class verbose_verification {
+  public:
+    verbose_verification(Verifier verifier)
+            : verifier_(verifier)
+    {}
 
-  bool operator()(
-    bool preverified,
-    boost::asio::ssl::verify_context& ctx
-  )
-  {
-    char subject_name[256], issuer_name[256];
-    X509* cert = X509_STORE_CTX_get_current_cert(ctx.native_handle());
-    X509_NAME_oneline(X509_get_subject_name(cert), subject_name, 256);
-    X509_NAME_oneline(X509_get_issuer_name(cert), issuer_name, 256);
-    bool verified = verifier_(preverified, ctx);
-    LOG_TRACE("Verifying %1%, issued by %2%. Verified: %3%", subject_name, issuer_name, verified);
-    return verified;
-  }
-private:
+    bool operator()(bool preverified,
+                    boost::asio::ssl::verify_context& ctx) {
+        char subject_name[256], issuer_name[256];
+        X509* cert = X509_STORE_CTX_get_current_cert(ctx.native_handle());
+        X509_NAME_oneline(X509_get_subject_name(cert), subject_name, 256);
+        X509_NAME_oneline(X509_get_issuer_name(cert), issuer_name, 256);
+        bool verified = verifier_(preverified, ctx);
+        LOG_TRACE("Verifying %1%, issued by %2%. Verified: %3%",
+                  subject_name, issuer_name, verified);
+        return verified;
+    }
+
+  private:
     Verifier verifier_;
 };
 

--- a/lib/src/connector/connection.cc
+++ b/lib/src/connector/connection.cc
@@ -26,6 +26,8 @@
 
 #include <leatherman/util/timer.hpp>
 
+#include <boost/format.hpp>
+
 #include <cstdio>
 #include <iostream>
 #include <random>
@@ -208,9 +210,11 @@ void Connection::connect(int max_connect_attempts) {
     } while (try_again);
 
     connection_backoff_ms_ = CONNECTION_BACKOFF_MS;
-    throw connection_fatal_error { "failed to establish a WebSocket connection "
-                                   "after " + std::to_string(idx) + " attempt"
-                                   + (idx > 1 ? "s" : "") };
+    throw connection_fatal_error {
+        (boost::format(
+            "failed to establish a WebSocket connection after %1% attempt%2%")
+                % std::to_string(idx)
+                % (idx > 1 ? "s" : "")).str() };
 }
 
 void Connection::send(const std::string& msg) {
@@ -248,7 +252,7 @@ void Connection::ping(const std::string& binary_payload) {
 }
 
 void Connection::close(CloseCode code, const std::string& reason) {
-    LOG_DEBUG("About to close connection");
+    LOG_DEBUG("About to close the WebSocket connection");
     websocketpp::lib::error_code ec;
     endpoint_->close(connection_handle_, code, reason, ec);
     if (ec) {
@@ -276,7 +280,7 @@ void Connection::tryClose() {
     try {
         close();
     } catch (connection_processing_error& e) {
-        LOG_ERROR("Cleanup failure: %1%", e.what());
+        LOG_WARNING("Cleanup failure: %1%", e.what());
     }
 }
 
@@ -307,11 +311,13 @@ void Connection::connect_() {
     websocketpp::lib::error_code ec;
     WS_Client_Type::connection_ptr connection_ptr {
         endpoint_->get_connection(broker_ws_uri_, ec) };
-    if (ec) {
-        throw connection_processing_error { "failed to establish the WebSocket "
-                                            "connection with " + broker_ws_uri_
-                                            + ": " + ec.message() };
-    }
+    if (ec)
+        throw connection_processing_error {
+            (boost::format("failed to establish the WebSocket connection "
+                           "with %1%: %2%")
+                % broker_ws_uri_
+                % ec.message()).str() };
+
     connection_handle_ = connection_ptr->get_handle();
     LOG_INFO("Connecting to '%1%' with a connection timeout of %2% ms",
               broker_ws_uri_, client_metadata_.connection_timeout);
@@ -372,19 +378,25 @@ WS_Context_Ptr Connection::onTlsInit(WS_Connection_Handle hdl) {
 
         auto uri = websocketpp::uri(broker_ws_uri_);
         ctx->set_verify_mode(boost::asio::ssl::verify_peer);
-        ctx->set_verify_callback(make_verbose_verification(boost::asio::ssl::rfc2818_verification(uri.get_host())));
+        ctx->set_verify_callback(
+            make_verbose_verification(
+                boost::asio::ssl::rfc2818_verification(uri.get_host())));
         LOG_TRACE("Initialized SSL context to verify broker %1%", uri.get_host());
     } catch (std::exception& e) {
         // This is unexpected, as the CliendMetadata ctor does
         // validate the key / cert pair
-        throw connection_config_error { std::string { "TLS error: " } + e.what() };
+        throw connection_config_error {
+            (boost::format("TLS error: %1%") % e.what()).str() };
     }
     return ctx;
 }
 
 void Connection::onClose(WS_Connection_Handle hdl) {
     connection_timings_.close = Util::chrono::high_resolution_clock::now();
-    LOG_TRACE("WebSocket connection closed");
+    auto con = endpoint_->get_con_from_hdl(hdl);
+    LOG_DEBUG("WebSocket on close event: %1% (code: %2%) - %3%",
+              con->get_ec().message(), con->get_remote_close_code(),
+              connection_timings_.toString());
     connection_state_ = ConnectionStateValues::closed;
 }
 
@@ -393,8 +405,8 @@ void Connection::onFail(WS_Connection_Handle hdl) {
     connection_timings_.connection_failed = true;
     auto con = endpoint_->get_con_from_hdl(hdl);
     LOG_DEBUG("WebSocket on fail event - %1%", connection_timings_.toString());
-    LOG_WARNING("WebSocket on fail event (connection loss): status code %1% - %2%",
-                con->get_remote_close_code(), con->get_ec().message());
+    LOG_WARNING("WebSocket on fail event (connection loss): %1% (code: %2%)",
+                con->get_ec().message(), con->get_remote_close_code());
     connection_state_ = ConnectionStateValues::closed;
 }
 

--- a/lib/src/connector/session_association.cc
+++ b/lib/src/connector/session_association.cc
@@ -1,0 +1,25 @@
+#include <cpp-pcp-client/connector/session_association.hpp>
+
+namespace PCPClient {
+
+SessionAssociation::SessionAssociation()
+        : success { false },
+          in_progress { false },
+          got_messaging_failure { false },
+          request_id {},
+          error {},
+          mtx {},
+          cond_var {}
+{
+}
+
+void SessionAssociation::reset()
+{
+    success = false;
+    in_progress = false;
+    got_messaging_failure = false;
+    request_id.clear();
+    error.clear();
+}
+
+}  // namespace PCPClient


### PR DESCRIPTION
- Style changes
- Improvements for log messages
- Associate Session:

Performing Associate Session only after Connection::connect() returns.
Terminating pxp-agent in case of an Associate Session failure.
Considering possible corrupted messages and PCP Errors during the
Session Association phase.

Considering a timeout when waiting for the Session Association outcome.

Blocking the associateSession() callback, triggered by the onOpen
handler, until Connection::connect() return, in order to avoid a data
race with the Connection's FSM in case of Associate Session failure.

Refactoring Session Association state attributes in a new class.
Defining new errors.

The Monitor Task will attempt to reconnect in case of a corrupted error
or timeout during Session Association.