### PR TITLE
(maint) Make tests compatible with leatherman 0.4 and 0.5

### DIFF
--- a/lib/tests/main.cc
+++ b/lib/tests/main.cc
@@ -4,8 +4,6 @@
 
 #include "test.hpp"
 
-#include <boost/nowide/iostream.hpp>
-
 #include <vector>
 
 // To enable log messages:
@@ -16,7 +14,7 @@
 #include <leatherman/logging/logging.hpp>
 #endif
 
-int main(int argc, const char** argv) {
+int main(int argc, char** argv) {
 #ifdef ENABLE_LOGGING
     leatherman::logging::setup_logging(boost::nowide::cout);
     leatherman::logging::set_level(leatherman::logging::log_level::debug);
@@ -24,14 +22,14 @@ int main(int argc, const char** argv) {
 
     // Create the Catch session, pass CL args, and start it
     Catch::Session test_session {};
-    test_session.applyCommandLine(argc, argv);
 
     // NOTE(ale): to list the reporters use:
     // test_session.configData().listReporters = true;
 
-    // Reporters: "xml", "junit", "console", and "compact" (single line)
-    test_session.configData().reporterNames =
-            std::vector<std::string> { "console" };
+    // NOTE(ale): out of the box, Reporters are "xml", "junit", "console",
+    // and "compact" (single line); "console" is the default
+    // test_session.configData().reporterNames =
+    //      std::vector<std::string> { "xml" };
 
     // ShowDurations::Always, ::Never, ::DefaultForReporter
     test_session.configData().showDurations = Catch::ShowDurations::Always;
@@ -39,5 +37,5 @@ int main(int argc, const char** argv) {
     // NOTE(ale): enforcing ConfigData::useColour == UseColour::No
     // on Windows is not necessary; the default ::Auto works fine
 
-    return test_session.run();
+    return test_session.run(argc, argv);
 }


### PR DESCRIPTION
Removing the Catch's applyCommandLine() and passing CLI arguments
directly to the Session::run() function; note that setting ConfigData
showDurations to "Always" works in the same way as it's not changed by
our CI pipeline via CLI.