### PR TITLE
(PCP-372) Support building with Leatherman DLLs

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -55,7 +55,6 @@ add_library(libcpp-pcp-client SHARED ${SOURCES})
 add_dependencies(libcpp-pcp-client websocketpp valijson)
 
 target_link_libraries(libcpp-pcp-client PRIVATE ${LIBS} ${PLATFORM_LIBS})
-set_target_properties(libcpp-pcp-client PROPERTIES PREFIX "" SUFFIX ".so" IMPORT_PREFIX "" IMPORT_SUFFIX ".so.a")
 
 # Generate the export header
 include(GenerateExportHeader)
@@ -68,10 +67,7 @@ if (WIN32)
     add_definitions("-Dlibcpp_pcp_client_EXPORTS")
 endif()
 
-install(TARGETS libcpp-pcp-client
-    RUNTIME DESTINATION bin
-    LIBRARY DESTINATION lib
-    ARCHIVE DESTINATION lib)
+leatherman_install(libcpp-pcp-client)
 install(DIRECTORY inc/cpp-pcp-client DESTINATION include)
 
 add_subdirectory(tests)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -22,10 +22,21 @@ set(SOURCES
     src/validator/validator.cc
 )
 
+# Static libraries should come before shared libraries, or you can end up
+# with some really annoying link errors. However, we can configure whether
+# Boost and Leatherman are linked statically or dynamically.
+if (LEATHERMAN_SHARED)
+    # If Leatherman is shared, Boost should come first because
+    # it's static, or the order doesn't matter.
+    list(APPEND LIBS ${Boost_LIBRARIES} ${LEATHERMAN_LIBRARIES})
+else()
+    # If Leatherman is static, it should come first as it depends
+    # on Boost.
+    list(APPEND LIBS ${LEATHERMAN_LIBRARIES} ${Boost_LIBRARIES})
+endif()
+
 # TODO(ale): remove Thread dependency after LTH-81 changes
-set(LIBS
-    ${LEATHERMAN_LIBRARIES}
-    ${Boost_LIBRARIES}
+list(APPEND LIBS
     ${OPENSSL_SSL_LIBRARY}
     ${OPENSSL_CRYPTO_LIBRARY}
     ${CMAKE_THREAD_LIBS_INIT}

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -29,7 +29,7 @@ include_directories(
 )
 
 add_executable(${test_BIN} ${SOURCES})
-target_link_libraries(${test_BIN} libcpp-pcp-client ${LEATHERMAN_LIBRARIES} ${Boost_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(${test_BIN} libcpp-pcp-client ${LIBS})
 
 add_custom_target(check
     "${EXECUTABLE_OUTPUT_PATH}/${test_BIN}"


### PR DESCRIPTION
Fix Leatherman and Boost library order so we can build with shared Leatherman libraries on Windows.