### PR TITLE
(PCP-371) Spike i18n

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /ext/packaging
 .DS_Store
 export.h
+/dev-resources/
 
 #Generated files
 /.idea/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,14 @@ if(DEV_LOG_RAW_MESSAGE)
     add_definitions(-DDEV_LOG_RAW_MESSAGE)
 endif()
 
+# TODO(ale): enable i18n with add_definitions(-DLEATHERMAN_I18N) - PCP-257
+# TODO(ale): enable translation with set(LEATHERMAN_LOCALES "...;...") and
+# gettext_compile(${CMAKE_CURRENT_SOURCE_DIR}/locales share/locale)
+
+# Configure i18n
+file(GLOB_RECURSE PCP_CLIENT_SOURCES */src/*.cc */inc/*.hpp)
+gettext_templates(${CMAKE_CURRENT_SOURCE_DIR}/locales ${PCP_CLIENT_SOURCES})
+
 # Prefer openssl from ports
 if ("${CMAKE_SYSTEM_NAME}" MATCHES "Darwin")
     set(CMAKE_LIBRARY_PATH ${CMAKE_LIBRARY_PATH} /opt/local/lib)

--- a/lib/inc/cpp-pcp-client/connector/timings.hpp
+++ b/lib/inc/cpp-pcp-client/connector/timings.hpp
@@ -2,6 +2,7 @@
 #define CPP_PCP_CLIENT_SRC_CONNECTOR_TIMINGS_H_
 
 #include <boost/chrono/chrono.hpp>
+
 #include <string>
 
 namespace PCPClient {
@@ -40,21 +41,6 @@ class ConnectionTimings {
     /// Returns a string with the timings
     std::string toString() const;
 };
-
-inline std::string ConnectionTimings::toString() const {
-    if (connection_started) {
-        return "connection timings: TCP "
-             + std::to_string(getTCPInterval().count()) + " us, WS handshake "
-             + std::to_string(getHandshakeInterval().count())
-             + " us, overall " + std::to_string(getWebSocketInterval().count())
-             + " us";
-    }
-    if (connection_failed) {
-        return "time to failure "
-             + std::to_string(getCloseInterval().count()) + " us";
-    }
-    return "the endpoint has not been connected yet";
-}
 
 }  // namespace PCPClient
 

--- a/lib/inc/cpp-pcp-client/protocol/serialization.hpp
+++ b/lib/inc/cpp-pcp-client/protocol/serialization.hpp
@@ -1,14 +1,17 @@
 #ifndef CPP_PCP_CLIENT_SRC_PROTOCOL_SERIALIZATION_H_
 #define CPP_PCP_CLIENT_SRC_PROTOCOL_SERIALIZATION_H_
 
-#include <cpp-pcp-client/protocol/errors.hpp>
 #include <cpp-pcp-client/export.h>
+#include <cpp-pcp-client/protocol/errors.hpp>
+
+#include <leatherman/locale/locale.hpp>
 
 #include <boost/detail/endian.hpp>
 
 #include <string>
 #include <vector>
 #include <stdint.h>  // uint8_t
+#include <utility>
 #include <stdexcept>
 
 // TODO(ale): disable assert() once we're confident with the code...
@@ -45,7 +48,7 @@ inline uint32_t getHostNumber(const uint32_t& number) {
 // Serialize
 //
 
-// Internal template function and speciatlizations
+// Internal template function and specializations
 
 template<typename T>
 inline void serialize_(const T& thing,
@@ -91,13 +94,15 @@ inline void serialize(const T& thing,
 
     try {
         buffer.resize(offset + thing_size);
-    } catch(std::bad_alloc) {
-        throw message_serialization_error { "serialization: bad allocation" };
-    } catch(const std::exception& e) {
+    } catch (std::bad_alloc) {
+        throw message_serialization_error {
+            leatherman::locale::translate("serialization: bad allocation") };
+    } catch (const std::exception& e) {
         throw message_serialization_error { e.what() };
-    } catch(...) {
-        throw message_serialization_error { "seriliazation: unexpected error "
-                                            "when allocating memory" };
+    } catch (...) {
+        throw message_serialization_error {
+            leatherman::locale::translate("serialization: unexpected error when "
+                                          "allocating memory") };
     }
 
     SerializedMessage::iterator buffer_itr = buffer.begin() + offset;

--- a/lib/src/connector/client_metadata.cc
+++ b/lib/src/connector/client_metadata.cc
@@ -7,12 +7,16 @@
 
 #include <leatherman/logging/logging.hpp>
 
+#include <leatherman/locale/locale.hpp>
+
 #include <openssl/x509v3.h>
 #include <openssl/ssl.h>
 
 #include <stdio.h>  // std::fopen
 
 namespace PCPClient {
+
+namespace lth_loc = leatherman::locale;
 
 // Get rid of OSX 10.7 and greater deprecation warnings.
 #if defined(__APPLE__) && defined(__clang__)
@@ -25,60 +29,65 @@ static const std::string PCP_URI_SCHEME { "pcp://" };
 // TODO(ale): consider moving the SSL functions elsewhere
 
 int pwdCallback(char *buf, int size, int rwflag, void *password) {
-    throw connection_config_error { "key is protected by password" };
+    throw connection_config_error {
+        lth_loc::translate("key is protected by password") };
     return EXIT_FAILURE;
 }
 
 void validatePrivateKeyCertPair(const std::string& key, const std::string& crt) {
-    LOG_TRACE("About to validate private key / certificate pair: '%1%' / '%2%'",
+    LOG_TRACE("About to validate private key / certificate pair: '{1}' / '{2}'",
               key, crt);
     auto ctx = SSL_CTX_new(SSLv23_method());
     leatherman::util::scope_exit ctx_cleaner {
         [ctx]() { SSL_CTX_free(ctx); }
     };
     if (ctx == nullptr) {
-        throw connection_config_error { "failed to create SSL context" };
+        throw connection_config_error {
+            lth_loc::translate("failed to create SSL context") };
     }
     SSL_CTX_set_default_passwd_cb(ctx, &pwdCallback);
     LOG_TRACE("Created SSL context");
     if (SSL_CTX_use_certificate_file(ctx, crt.c_str(), SSL_FILETYPE_PEM) <= 0) {
-        throw connection_config_error { "failed to open cert" };
+        throw connection_config_error { lth_loc::translate("failed to open cert") };
     }
     LOG_TRACE("Certificate loaded");
     if (SSL_CTX_use_PrivateKey_file(ctx, key.c_str(), SSL_FILETYPE_PEM) <= 0) {
-        throw connection_config_error { "failed to load private key" };
+        throw connection_config_error {
+            lth_loc::translate("failed to load private key") };
     }
     LOG_TRACE("Private key loaded");
     if (!SSL_CTX_check_private_key(ctx)) {
-        throw connection_config_error { "mismatch between private key and cert " };
+        throw connection_config_error {
+            lth_loc::translate("mismatch between private key and cert") };
     }
     LOG_TRACE("Private key / certificate pair has been successfully validated");
 }
 
 std::string getCommonNameFromCert(const std::string& crt) {
-    LOG_TRACE("Retrieving client name from certificate '%1%'", crt);
+    LOG_TRACE("Retrieving client name from certificate '{1}'", crt);
     std::unique_ptr<std::FILE, int(*)(std::FILE*)> fp {
         std::fopen(crt.data(), "r"), std::fclose };
 
     if (fp == nullptr) {
-        throw connection_config_error { "certificate file '" + crt
-                                        + "' does not exist" };
+        throw connection_config_error {
+            lth_loc::format("certificate file '{1}' does not exist", crt) };
     }
 
     std::unique_ptr<X509, void(*)(X509*)> cert {
         PEM_read_X509(fp.get(), NULL, NULL, NULL), X509_free };
 
     if (cert == nullptr) {
-        throw connection_config_error { "certificate file '" + crt
-                                        + "' is invalid" };
+        throw connection_config_error {
+            lth_loc::format("certificate file '{1}' is invalid", crt) };
     }
 
     auto subj = X509_get_subject_name(cert.get());
     auto name_entry = X509_NAME_get_entry(subj, 0);
 
     if (name_entry == nullptr) {
-        throw connection_config_error { "failed to retrieve the client common "
-                                        "name from " + crt };
+        throw connection_config_error {
+            lth_loc::format("failed to retrieve the client common name "
+                            "from '{1}'", crt) };
     }
 
     ASN1_STRING* asn1_name = X509_NAME_ENTRY_get_data(name_entry);
@@ -105,7 +114,7 @@ ClientMetadata::ClientMetadata(const std::string& _client_type,
           uri { PCP_URI_SCHEME + common_name + "/" + client_type },
           connection_timeout { _connection_timeout } {
     LOG_INFO("Retrieved common name from the certificate and determined "
-             "the client URI: %1%", uri);
+             "the client URI: {1}", uri);
     validatePrivateKeyCertPair(key, crt);
     LOG_DEBUG("Validated the private key / certificate pair");
 }

--- a/lib/src/connector/timings.cc
+++ b/lib/src/connector/timings.cc
@@ -1,8 +1,10 @@
 #include <cpp-pcp-client/connector/timings.hpp>
 
-#include <sstream>
+#include <leatherman/locale/locale.hpp>
 
 namespace PCPClient {
+
+namespace lth_loc = leatherman::locale;
 
 ConnectionTimings::ConnectionTimings()
         : start { boost::chrono::high_resolution_clock::now() } {
@@ -26,6 +28,20 @@ ConnectionTimings::Duration_us ConnectionTimings::getWebSocketInterval() const {
 ConnectionTimings::Duration_us ConnectionTimings::getCloseInterval() const {
     return boost::chrono::duration_cast<ConnectionTimings::Duration_us>(
         close - start);
+}
+
+std::string ConnectionTimings::toString() const {
+    if (connection_started)
+        return lth_loc::format(
+            "connection timings: TCP {1} us, WS handshake {2} us, overall {3} us",
+            getTCPInterval().count(),
+            getHandshakeInterval().count(),
+            getWebSocketInterval().count());
+
+    if (connection_failed)
+        return lth_loc::format("time to failure {1} us", getCloseInterval().count());
+
+    return lth_loc::translate("the endpoint has not been connected yet");
 }
 
 }  // namespace PCPClient

--- a/lib/src/protocol/serialization.cc
+++ b/lib/src/protocol/serialization.cc
@@ -1,4 +1,5 @@
 #include <cpp-pcp-client/protocol/serialization.hpp>
+
 #if _WIN32
 #include <Winsock2.h>
 #else
@@ -9,11 +10,13 @@ namespace PCPClient {
 
 #ifdef BOOST_LITTLE_ENDIAN
 
-uint32_t getNetworkNumber(const uint32_t& number) {
+uint32_t getNetworkNumber(const uint32_t& number)
+{
     return htonl(number);
 }
 
-uint32_t getHostNumber(const uint32_t& number) {
+uint32_t getHostNumber(const uint32_t& number)
+{
     return ntohl(number);
 }
 

--- a/lib/src/validator/schema.cc
+++ b/lib/src/validator/schema.cc
@@ -7,11 +7,14 @@
 #include <cpp-pcp-client/valijson/rapidjson_adapter.hpp>
 #pragma GCC diagnostic pop
 
+#include <leatherman/locale/locale.hpp>
+
 #include <rapidjson/allocators.h>
 
 namespace PCPClient {
 
-namespace lth_jc = leatherman::json_container;
+namespace lth_jc  = leatherman::json_container;
+namespace lth_loc = leatherman::locale;
 
 //
 // Free functions
@@ -81,9 +84,9 @@ Schema::Schema(const std::string& name, const lth_jc::JsonContainer& metadata)
               pattern_properties_ { new V_C::PropertiesConstraint::PropertySchemaMap() },
               required_properties_ { new V_C::RequiredConstraint::RequiredProperties() } {
 } catch (std::exception& e) {
-    throw schema_error { std::string("failed to parse schema: ") + e.what() };
+    throw schema_error { lth_loc::format("failed to parse schema: {1}", e.what()) };
 } catch (...) {
-    throw schema_error { "failed to parse schema" };
+    throw schema_error { lth_loc::translate("failed to parse schema") };
 }
 
 // unique_ptr requires a complete type at time of destruction. this forces us to
@@ -173,11 +176,12 @@ V_C::TypeConstraint Schema::getConstraint(TypeConstraint type) const {
 
 void Schema::checkAddConstraint() {
     if (parsed_) {
-        throw schema_error { "schema was populate by parsing JSON" };
+        throw schema_error {
+            lth_loc::translate("schema was populate by parsing JSON") };
     }
 
     if (type_ != TypeConstraint::Object) {
-        throw schema_error { "type is not JSON Object" };
+        throw schema_error { lth_loc::translate("type is not JSON Object") };
     }
 }
 

--- a/locales/cpp-pcp-client.pot
+++ b/locales/cpp-pcp-client.pot
@@ -1,0 +1,583 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR Puppet Labs <docs@puppetlabs.com>
+# This file is distributed under the same license as the cpp-pcp-client package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: cpp-pcp-client 1.1.3\n"
+"Report-Msgid-Bugs-To: docs@puppetlabs.com\n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: lib/inc/cpp-pcp-client/protocol/serialization.hpp:99
+msgid "serialization: bad allocation"
+msgstr ""
+
+#: lib/inc/cpp-pcp-client/protocol/serialization.hpp:104
+msgid "serialization: unexpected error when allocating memory"
+msgstr ""
+
+#: lib/src/connector/client_metadata.cc:33
+msgid "key is protected by password"
+msgstr ""
+
+#: lib/src/connector/client_metadata.cc:46
+msgid "failed to create SSL context"
+msgstr ""
+
+#: lib/src/connector/client_metadata.cc:51
+msgid "failed to open cert"
+msgstr ""
+
+#: lib/src/connector/client_metadata.cc:56
+msgid "failed to load private key"
+msgstr ""
+
+#: lib/src/connector/client_metadata.cc:61
+msgid "mismatch between private key and cert"
+msgstr ""
+
+#: lib/src/connector/client_metadata.cc:73
+msgid "certificate file '{1}' does not exist"
+msgstr ""
+
+#: lib/src/connector/client_metadata.cc:81
+msgid "certificate file '{1}' is invalid"
+msgstr ""
+
+#: lib/src/connector/client_metadata.cc:89
+msgid "failed to retrieve the client common name from '{1}'"
+msgstr ""
+
+#. info
+#: lib/src/connector/client_metadata.cc:116
+msgid ""
+"Retrieved common name from the certificate and determined the client URI: {1}"
+msgstr ""
+
+#. debug
+#: lib/src/connector/client_metadata.cc:119
+msgid "Validated the private key / certificate pair"
+msgstr ""
+
+#. debug
+#: lib/src/connector/connection.cc:103
+msgid ""
+"Failed to configure the WebSocket endpoint; about to stop the event loop"
+msgstr ""
+
+#: lib/src/connector/connection.cc:106
+msgid "failed to initialize"
+msgstr ""
+
+#. warning
+#: lib/src/connector/connection.cc:198
+msgid "Failed to establish a WebSocket connection; retrying in {1} seconds"
+msgstr ""
+
+#: lib/src/connector/connection.cc:216
+msgid "failed to establish a WebSocket connection after {1} attempts"
+msgstr ""
+
+#: lib/src/connector/connection.cc:228
+#: lib/src/connector/connection.cc:240
+msgid "failed to send message: {1}"
+msgstr ""
+
+#: lib/src/connector/connection.cc:248
+msgid "failed to send WebSocket ping: {1}"
+msgstr ""
+
+#. debug
+#: lib/src/connector/connection.cc:253
+msgid "About to close the WebSocket connection"
+msgstr ""
+
+#: lib/src/connector/connection.cc:258
+msgid "failed to close WebSocket connection: {1}"
+msgstr ""
+
+#. warning
+#: lib/src/connector/connection.cc:281
+msgid "Cleanup failure: {1}"
+msgstr ""
+
+#. warning
+#: lib/src/connector/connection.cc:292
+msgid "Will wait {1} ms before terminating the WebSocket connection"
+msgstr ""
+
+#: lib/src/connector/connection.cc:314
+msgid "failed to establish the WebSocket connection with {1}: {2}"
+msgstr ""
+
+#. info
+#: lib/src/connector/connection.cc:318
+msgid "Connecting to '{1}' with a connection timeout of {2} ms"
+msgstr ""
+
+#. debug
+#: lib/src/connector/connection.cc:342
+msgid "Verifying {1}, issued by {2}. Verified: {3}"
+msgstr ""
+
+#. debug
+#: lib/src/connector/connection.cc:360
+msgid "WebSocket TLS initialization event; about to validate the certificate"
+msgstr ""
+
+#. debug
+#: lib/src/connector/connection.cc:380
+msgid "Initialized SSL context to verify broker {1}"
+msgstr ""
+
+#: lib/src/connector/connection.cc:385
+msgid "TLS error: {1}"
+msgstr ""
+
+#. debug
+#: lib/src/connector/connection.cc:393
+msgid "WebSocket on close event: {1} (code: {2}) - {3}"
+msgstr ""
+
+#. debug
+#: lib/src/connector/connection.cc:403
+msgid "WebSocket on fail event - {1}"
+msgstr ""
+
+#. warning
+#: lib/src/connector/connection.cc:404
+msgid "WebSocket on fail event (connection loss): {1} (code: {2})"
+msgstr ""
+
+#. debug
+#: lib/src/connector/connection.cc:416
+msgid "WebSocket onPong event"
+msgstr ""
+
+#. warning
+#: lib/src/connector/connection.cc:424
+msgid "WebSocket onPongTimeout event ({1} consecutive)"
+msgstr ""
+
+#. debug
+#: lib/src/connector/connection.cc:441
+msgid "WebSocket on open event - {1}"
+msgstr ""
+
+#. info
+#: lib/src/connector/connection.cc:442
+msgid ""
+"Successfully established a WebSocket connection with the PCP broker at {1}"
+msgstr ""
+
+#. error
+#: lib/src/connector/connection.cc:451
+msgid "onOpen callback failure: {1}; closing the WebSocket connection"
+msgstr ""
+
+#. error
+#: lib/src/connector/connection.cc:454
+msgid "onOpen callback failure; closing the WebSocket connection"
+msgstr ""
+
+#. error
+#: lib/src/connector/connection.cc:470
+msgid "onMessage WebSocket callback failure: {1}"
+msgstr ""
+
+#. error
+#: lib/src/connector/connection.cc:472
+msgid "onMessage WebSocket callback failure: unexpected error"
+msgstr ""
+
+#. info
+#: lib/src/connector/connector.cc:96
+msgid "Resetting the WebSocket event callbacks"
+msgstr ""
+
+#. debug
+#: lib/src/connector/connector.cc:160
+msgid ""
+"There's an ongoing attempt to create a WebSocket connection; ensuring that "
+"it's closed before Associate Session"
+msgstr ""
+
+#. warning
+#: lib/src/connector/connector.cc:176
+msgid "Unexpected - failed to close the WebSocket connection"
+msgstr ""
+
+#. warning
+#: lib/src/connector/connector.cc:182
+msgid ""
+"WebSocket close failure ({1}); will continue with the Associate Session "
+"attempt"
+msgstr ""
+
+#. info
+#: lib/src/connector/connector.cc:209
+msgid "Waiting for the PCP Session Association to complete"
+msgstr ""
+
+#. debug
+#: lib/src/connector/connector.cc:220
+msgid "It seems that an error occurred during the Session Association ({1})"
+msgstr ""
+
+#: lib/src/connector/connector.cc:223
+msgid "undetermined error"
+msgstr ""
+
+#: lib/src/connector/connector.cc:227
+msgid "invalid Associate Session response"
+msgstr ""
+
+#. debug
+#: lib/src/connector/connector.cc:230
+msgid "Associate Session timed out"
+msgstr ""
+
+#: lib/src/connector/connector.cc:233
+msgid "operation timeout"
+msgstr ""
+
+#: lib/src/connector/connector.cc:236
+msgid "Associate Session failure"
+msgstr ""
+
+#. debug
+#: lib/src/connector/connector.cc:249
+msgid "Failed to establish the WebSocket connection: {1}"
+msgstr ""
+
+#. warning
+#: lib/src/connector/connector.cc:270
+msgid "The monitorConnection function has already been called"
+msgstr ""
+
+#. debug
+#: lib/src/connector/connector.cc:279
+msgid ""
+"Sending message of {1} bytes:\n"
+"{2}"
+msgstr ""
+
+#: lib/src/connector/connector.cc:347
+msgid "connection not initialized"
+msgstr ""
+
+#. debug
+#: lib/src/connector/connector.cc:359
+msgid "Creating message with id {1} for {2} receivers"
+msgstr ""
+
+#. debug
+#: lib/src/connector/connector.cc:407
+msgid ""
+"About to send Associate Session request; unexpectedly the Connector does not "
+"seem to be in the associating state"
+msgstr ""
+
+#. info
+#: lib/src/connector/connector.cc:425
+msgid "Sending Associate Session request with id {1}"
+msgstr ""
+
+#. debug
+#: lib/src/connector/connector.cc:434
+msgid ""
+"Received message of {1} bytes - raw message:\n"
+"{2}"
+msgstr ""
+
+#: lib/src/connector/connector.cc:445
+msgid "Failed to deserialize message: {1}"
+msgstr ""
+
+#: lib/src/connector/connector.cc:455
+msgid "Invalid envelope - bad content: {1}"
+msgstr ""
+
+#: lib/src/connector/connector.cc:457
+msgid "Invalid envelope - invalid JSON content: {1}"
+msgstr ""
+
+#: lib/src/connector/connector.cc:461
+msgid "Unknown schema: {1}"
+msgstr ""
+
+#. warning
+#: lib/src/connector/connector.cc:487
+msgid "No message callback has be registered for the '{1}' schema"
+msgstr ""
+
+#. warning
+#: lib/src/connector/connector.cc:506
+msgid "Received an unexpected Associate Session response; discarding it"
+msgstr ""
+
+#. warning
+#: lib/src/connector/connector.cc:512
+msgid ""
+"Received an Associate Session response that refers to an unknown request ID "
+"({1}, expected {2}); discarding it"
+msgstr ""
+
+#: lib/src/connector/connector.cc:518
+msgid "Received an Associate Session response {1} from {2} for the request {3}"
+msgstr ""
+
+#. info
+#: lib/src/connector/connector.cc:523
+msgid "{1}: success"
+msgstr ""
+
+#. warning
+#: lib/src/connector/connector.cc:527
+msgid "{1}: failure - {2}"
+msgstr ""
+
+#. warning
+#: lib/src/connector/connector.cc:530
+msgid "{1}: failure"
+msgstr ""
+
+#: lib/src/connector/connector.cc:554
+msgid "Received error {1} from {2}"
+msgstr ""
+
+#. warning
+#: lib/src/connector/connector.cc:559
+msgid "{1} caused by message {2}: {3}"
+msgstr ""
+
+#. warning
+#: lib/src/connector/connector.cc:561
+msgid "{1} (the id of the message that caused it is unknown): {2}"
+msgstr ""
+
+#. debug
+#: lib/src/connector/connector.cc:572
+msgid "The error message {1} is due to the Associate Session request {2}"
+msgstr ""
+
+#. warning
+#: lib/src/connector/connector.cc:592
+msgid "Received TTL Expired message {1} from {2} related to message {3}"
+msgstr ""
+
+#. debug
+#: lib/src/connector/connector.cc:604
+msgid ""
+"The TTL expired message {1} is related to the Associate Session request {2}"
+msgstr ""
+
+#. info
+#: lib/src/connector/connector.cc:619
+msgid "Starting the monitor task"
+msgstr ""
+
+#. warning
+#: lib/src/connector/connector.cc:635
+msgid "WebSocket connection to PCP broker lost; retrying"
+msgstr ""
+
+#. debug
+#: lib/src/connector/connector.cc:638
+msgid "Sending heartbeat ping"
+msgstr ""
+
+#. warning
+#: lib/src/connector/connector.cc:644
+msgid ""
+"The connection monitor task will continue after a WebSocket failure ({1})"
+msgstr ""
+
+#. warning
+#: lib/src/connector/connector.cc:648
+msgid ""
+"The connection monitor task will continue after an error during the Session "
+"Association ({1})"
+msgstr ""
+
+#. warning
+#: lib/src/connector/connector.cc:652
+msgid ""
+"The connection monitor task will stop after an Session Association failure: "
+"{1}"
+msgstr ""
+
+#. warning
+#: lib/src/connector/connector.cc:658
+msgid "The connection monitor task will stop: {1}"
+msgstr ""
+
+#. info
+#: lib/src/connector/connector.cc:664
+msgid "Stopping the monitor task"
+msgstr ""
+
+#: lib/src/connector/timings.cc:36
+msgid "connection timings: TCP {1} us, WS handshake {2} us, overall {3} us"
+msgstr ""
+
+#: lib/src/connector/timings.cc:42
+msgid "time to failure {1} us"
+msgstr ""
+
+#: lib/src/connector/timings.cc:44
+msgid "the endpoint has not been connected yet"
+msgstr ""
+
+#. warning
+#: lib/src/protocol/message.cc:87
+msgid "Resetting data chunk"
+msgstr ""
+
+#. debug
+#: lib/src/protocol/message.cc:178
+#: lib/src/protocol/message.cc:181
+msgid "Invalid debug in message {1}: {2}"
+msgstr ""
+
+#. debug
+#: lib/src/protocol/message.cc:207
+msgid "Invalid data in message {1}: {2}"
+msgstr ""
+
+#. error
+#: lib/src/protocol/message.cc:254
+msgid "Invalid msg; envelope is too small"
+msgstr ""
+
+#: lib/src/protocol/message.cc:257
+msgid "invalid msg: envelope too small"
+msgstr ""
+
+#. error
+#: lib/src/protocol/message.cc:275
+msgid "Invalid msg; missing envelope descriptor"
+msgstr ""
+
+#: lib/src/protocol/message.cc:278
+msgid "invalid msg: no envelope descriptor"
+msgstr ""
+
+#. error
+#: lib/src/protocol/message.cc:283
+msgid "Invalid msg; missing envelope content"
+msgstr ""
+
+#: lib/src/protocol/message.cc:286
+msgid "invalid msg: no envelope"
+msgstr ""
+
+#. error
+#: lib/src/protocol/message.cc:302
+msgid "Invalid msg; invalid chunk descriptor {1}"
+msgstr ""
+
+#: lib/src/protocol/message.cc:306
+msgid "invalid msg: invalid chunk descriptor"
+msgstr ""
+
+#. error
+#: lib/src/protocol/message.cc:312
+msgid ""
+"Invalid msg; missing part of the {1} chunk content ({2} bytes declared - "
+"missing {3} bytes)"
+msgstr ""
+
+#: lib/src/protocol/message.cc:318
+msgid "invalid msg: missing chunk content"
+msgstr ""
+
+#. error
+#: lib/src/protocol/message.cc:326
+msgid "Invalid msg; multiple data chunks"
+msgstr ""
+
+#: lib/src/protocol/message.cc:330
+msgid "invalid msg: multiple data chunks"
+msgstr ""
+
+#. error
+#: lib/src/protocol/message.cc:343
+msgid ""
+"Failed to parse the entire msg (ignoring last {1} bytes); the msg will be "
+"processed anyway"
+msgstr ""
+
+#. error
+#: lib/src/protocol/message.cc:359
+msgid "Unsupported message version: {1}"
+msgstr ""
+
+#: lib/src/protocol/message.cc:361
+msgid "unsupported message version: {1}"
+msgstr ""
+
+#. error
+#: lib/src/protocol/message.cc:369
+msgid "Unknown chunk descriptor: {1}"
+msgstr ""
+
+#: lib/src/protocol/message.cc:371
+msgid "unknown descriptor"
+msgstr ""
+
+#. error
+#: lib/src/protocol/message.cc:376
+msgid "Incorrect size for {1} chunk; declared {2} bytes, got {3} bytes"
+msgstr ""
+
+#: lib/src/protocol/message.cc:378
+msgid "invalid size"
+msgstr ""
+
+#: lib/src/validator/schema.cc:87
+msgid "failed to parse schema: {1}"
+msgstr ""
+
+#: lib/src/validator/schema.cc:89
+msgid "failed to parse schema"
+msgstr ""
+
+#: lib/src/validator/schema.cc:180
+msgid "schema was populate by parsing JSON"
+msgstr ""
+
+#: lib/src/validator/schema.cc:184
+msgid "type is not JSON Object"
+msgstr ""
+
+#: lib/src/validator/validator.cc:30
+msgid "ERROR"
+msgstr ""
+
+#. debug
+#: lib/src/validator/validator.cc:55
+msgid "Schema validation failure: {1}"
+msgstr ""
+
+#: lib/src/validator/validator.cc:80
+msgid "schema '{1}' already defined"
+msgstr ""
+
+#: lib/src/validator/validator.cc:92
+#: lib/src/validator/validator.cc:112
+msgid "'{1}' is not a registered schema"
+msgstr ""
+
+#: lib/src/validator/validator.cc:100
+msgid "does not match schema: '{1}'"
+msgstr ""


### PR DESCRIPTION
Enable the creation of the .pot file that includes the strings that
we want to translate. Don't enable localization now; we'll do that on
PCP-257.

Use leatherman::locale::format() and translate() for the strings that we
want to translate.

Use "{<int>}" instead of "%<int>%" for string interpolation.

Don't use leatherman::util::plural(); we'll deal with plurals once we
enable localization on PCP-257.