### PR TITLE
(maint) Make static/shared libraries toggleable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,8 @@ if (NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel." FORCE)
 endif()
 
+option(BUILD_SHARED_LIBS "Build shared library for cpp-pcp-client if on, otherwise build static libs" ON)
+
 # Set the macro for leatherman's logging namespace
 add_definitions(-DCPP_PCP_CLIENT_LOGGING_PREFIX="puppetlabs.cpp_pcp_client")
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -48,7 +48,7 @@ elseif ("${CMAKE_SYSTEM_NAME}" MATCHES "SunOS")
     set(PLATFORM_LIBS socket nsl)
 endif()
 
-add_library(libcpp-pcp-client SHARED ${SOURCES})
+add_library(libcpp-pcp-client ${SOURCES})
 
 # Explicit dependency on external projects to ensure they get
 # extracted when building with multiple jobs


### PR DESCRIPTION
Configure the cpp-pcp-client library so we can use a CMake option to
declare whether it will be built as a static or shared library. Default
to shared.