### PR TITLE
(maint) Download CMake from our S3 bucket

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_install:
   # location is defined at compile-time.
   - mkdir -p $USERDIR
   # Grab a pre-built cmake 3.2.3
-  - wget --no-check-certificate https://cmake.org/files/v3.2/cmake-3.2.3-Linux-x86_64.tar.gz
+  - wget https://s3.amazonaws.com/kylo-pl-bucket/cmake-3.2.3-Linux-x86_64.tar.gz
   - tar xzvf cmake-3.2.3-Linux-x86_64.tar.gz --strip 1 -C $USERDIR
   # Install cpp-pcp-client's dependencies
   - wget https://github.com/puppetlabs/leatherman/releases/download/${LEATHERMAN_VERSION}/leatherman.tar.gz


### PR DESCRIPTION
It's much faster than downloading from cmake.org.