### PR TITLE
(PCP-270) Restore linking threads for AIX

### DIFF
--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -21,6 +21,8 @@ set(test_BIN cpp-pcp-client-unittests)
 
 find_package(Boost 1.54 REQUIRED
   COMPONENTS filesystem system date_time thread log regex random)
+# Required on AIX
+find_package(Threads)
 
 include_directories(
     ${LEATHERMAN_CATCH_INCLUDE}
@@ -28,7 +30,11 @@ include_directories(
 )
 
 add_executable(${test_BIN} ${SOURCES})
-target_link_libraries(${test_BIN} libcpp-pcp-client ${LIBS})
+target_link_libraries(${test_BIN}
+    libcpp-pcp-client
+    ${LIBS}
+    ${CMAKE_THREAD_LIBS_INIT}
+)
 
 add_custom_target(check
     "${EXECUTABLE_OUTPUT_PATH}/${test_BIN}"


### PR DESCRIPTION
AIX linking requires declaring the dependency on pthreads explicitly.
Restore it.