### PR TITLE
Revert "(PCP-270) Remove outsourced pthread dependency"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,10 @@ find_package(Leatherman REQUIRED
 find_package(Boost 1.54 REQUIRED
   COMPONENTS filesystem chrono system date_time thread log regex random)
 find_package(OpenSSL REQUIRED)
+# TODO(ale): same fix as FACT-1338; remove it once LTH-81 is done.
+# date_time and regex need threads on some platforms, and find_package
+# Boost only includes pthreads if you require Boost.Thread component.
+find_package(Threads)
 
 # Leatherman it up
 include(options)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -35,9 +35,11 @@ else()
     list(APPEND LIBS ${LEATHERMAN_LIBRARIES} ${Boost_LIBRARIES})
 endif()
 
+# TODO(ale): remove Thread dependency after LTH-81 changes
 list(APPEND LIBS
     ${OPENSSL_SSL_LIBRARY}
     ${OPENSSL_CRYPTO_LIBRARY}
+    ${CMAKE_THREAD_LIBS_INIT}
 )
 
 if (WIN32)

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -22,6 +22,7 @@ set(test_BIN cpp-pcp-client-unittests)
 find_package(Boost 1.54 REQUIRED
   COMPONENTS filesystem system date_time thread log regex random)
 
+# TODO(ale): remove Thread dependency after LTH-81 changes
 include_directories(
     ${LEATHERMAN_CATCH_INCLUDE}
     ${Boost_INCLUDE_DIRS}


### PR DESCRIPTION
Reverts puppetlabs/cpp-pcp-client#157

Still required on AIX.