### PR TITLE
(maint) Update comments noting that AIX requires threads

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,9 +44,7 @@ find_package(Leatherman REQUIRED
 find_package(Boost 1.54 REQUIRED
   COMPONENTS filesystem chrono system date_time thread log regex random)
 find_package(OpenSSL REQUIRED)
-# TODO(ale): same fix as FACT-1338; remove it once LTH-81 is done.
-# date_time and regex need threads on some platforms, and find_package
-# Boost only includes pthreads if you require Boost.Thread component.
+# Needed for linking on AIX
 find_package(Threads)
 
 # Leatherman it up

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -35,7 +35,6 @@ else()
     list(APPEND LIBS ${LEATHERMAN_LIBRARIES} ${Boost_LIBRARIES})
 endif()
 
-# TODO(ale): remove Thread dependency after LTH-81 changes
 list(APPEND LIBS
     ${OPENSSL_SSL_LIBRARY}
     ${OPENSSL_CRYPTO_LIBRARY}

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -22,7 +22,6 @@ set(test_BIN cpp-pcp-client-unittests)
 find_package(Boost 1.54 REQUIRED
   COMPONENTS filesystem system date_time thread log regex random)
 
-# TODO(ale): remove Thread dependency after LTH-81 changes
 include_directories(
     ${LEATHERMAN_CATCH_INCLUDE}
     ${Boost_INCLUDE_DIRS}


### PR DESCRIPTION
AIX linking requires declaring the dependency on pthreads explicitly.