### PR TITLE
Revert "(maint) Ban long integers"

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ The constructor of the Connector class is defined as:
               std::string ca_crt_path,
               std::string client_crt_path,
               std::string client_key_path,
-              int64_t connection_timeout = 5000)
+              long connection_timeout = 5000)
 ```
 
 The parameters are described as:

--- a/lib/inc/cpp-pcp-client/connector/client_metadata.hpp
+++ b/lib/inc/cpp-pcp-client/connector/client_metadata.hpp
@@ -18,7 +18,7 @@ class LIBCPP_PCP_CLIENT_EXPORT ClientMetadata {
     std::string client_type;
     std::string common_name;
     std::string uri;
-    int64_t connection_timeout;
+    long connection_timeout;
 
     /// Throws a connection_config_error in case: the client
     /// certificate file does not exist or is invalid; it fails to
@@ -28,7 +28,7 @@ class LIBCPP_PCP_CLIENT_EXPORT ClientMetadata {
                    std::string _ca,
                    std::string _crt,
                    std::string _key,
-                   int64_t _connection_timeout);
+                   long _connection_timeout);
 };
 
 }  // namespace PCPClient

--- a/lib/inc/cpp-pcp-client/connector/connector.hpp
+++ b/lib/inc/cpp-pcp-client/connector/connector.hpp
@@ -41,7 +41,7 @@ class LIBCPP_PCP_CLIENT_EXPORT Connector {
               std::string ca_crt_path,
               std::string client_crt_path,
               std::string client_key_path,
-              int64_t connection_timeout = 5000);
+              long connection_timeout = 5000);
 
     ~Connector();
 

--- a/lib/src/connector/client_metadata.cc
+++ b/lib/src/connector/client_metadata.cc
@@ -105,7 +105,7 @@ ClientMetadata::ClientMetadata(std::string _client_type,
                                std::string _ca,
                                std::string _crt,
                                std::string _key,
-                               int64_t _connection_timeout)
+                               long _connection_timeout)
         : ca { std::move(_ca) },
           crt { std::move(_crt) },
           key { std::move(_key) },

--- a/lib/src/connector/connector.cc
+++ b/lib/src/connector/connector.cc
@@ -46,7 +46,7 @@ Connector::Connector(std::string broker_ws_uri,
                      std::string ca_crt_path,
                      std::string client_crt_path,
                      std::string client_key_path,
-                     int64_t connection_timeout)
+                     long connection_timeout)
         : broker_ws_uri_ { std::move(broker_ws_uri) },
           client_metadata_ { std::move(client_type),
                              std::move(ca_crt_path),

--- a/lib/tests/unit/protocol/serialization_test.cc
+++ b/lib/tests/unit/protocol/serialization_test.cc
@@ -53,7 +53,7 @@ TEST_CASE("PCPClient::serialize", "[message]") {
         REQUIRE(std::string(buffer.begin(), buffer.end()) == s_1 + s_2 + s_3);
     }
 
-    SECTION("can serialize an unsigned integer (4 bytes)") {
+    SECTION("can serialize an unsigned long integer (4 bytes)") {
         uint32_t n { 42 };
         SerializedMessage buffer;
         serialize<uint32_t>(n, 4, buffer);
@@ -62,7 +62,7 @@ TEST_CASE("PCPClient::serialize", "[message]") {
         REQUIRE(buffer == std::vector<uint8_t>({ 0, 0, 0, 0x2A }));
     }
 
-    SECTION("can serialize an unsigned integer (4 bytes) storing a number "
+    SECTION("can serialize an unsigned long integer (4 bytes) storing a number "
             "encoded with multiple bytes") {
         uint32_t n { 271828 };
         SerializedMessage buffer;
@@ -72,7 +72,7 @@ TEST_CASE("PCPClient::serialize", "[message]") {
         REQUIRE(buffer == std::vector<uint8_t>({ 0, 0x4, 0x25, 0xD4 }));
     }
 
-    SECTION("can serialize multiple integers") {
+    SECTION("can serialize multiple long integers") {
         uint32_t n_1 { 271828 };
         uint32_t n_2 { 314159 };
 
@@ -136,7 +136,7 @@ TEST_CASE("PCPClient::deserialize", "[message]") {
         REQUIRE(n_4 == 127);
     }
 
-    SECTION("can deserialize an integer") {
+    SECTION("can deserialize a long integer") {
         uint32_t n { 271828 };
         SerializedMessage n_buffer;
         serialize<uint32_t>(n, 4, n_buffer);
@@ -147,7 +147,7 @@ TEST_CASE("PCPClient::deserialize", "[message]") {
         REQUIRE(n_deserialized == 271828);
     }
 
-    SECTION("can deserialize multiple integers") {
+    SECTION("can deserialize multiple long integers") {
         auto n_vector = std::vector<uint32_t>({ 271828, 0, 1, 128, 1025 });
         SerializedMessage n_buffer;
         for (const auto& n : n_vector)


### PR DESCRIPTION
This reverts commit 1ea5c3a8a15ba9a7ff78ed131892ab4e7439fcdf.

`long` is used for a websocketpp API that expects a long. Avoid compile
errors on 32-bit platforms and Windows (they may not happen everywhere,
because GCC doesn't give conversion warnings with our config).