### PR TITLE
(maint) Add no_sslv3 to avoid ambiguity around protocols

### DIFF
--- a/lib/src/connector/connection.cc
+++ b/lib/src/connector/connection.cc
@@ -362,8 +362,12 @@ WS_Context_Ptr Connection::onTlsInit(WS_Connection_Handle hdl) {
     WS_Context_Ptr ctx {
         new boost::asio::ssl::context(boost::asio::ssl::context::tlsv1) };
     try {
+        // no_sslv2 and no_sslv3 here are not strictly necessary, as the tlsv1 method above
+        // ensures we will not try to initiate any connection below TLSv1. However, this avoids
+        // any ambiguity in what we support.
         ctx->set_options(boost::asio::ssl::context::default_workarounds |
                          boost::asio::ssl::context::no_sslv2 |
+                         boost::asio::ssl::context::no_sslv3 |
                          boost::asio::ssl::context::single_dh_use);
         ctx->use_certificate_file(client_metadata_.crt,
                                   boost::asio::ssl::context::file_format::pem);


### PR DESCRIPTION
The lack of `no_sslv3` doesn't affect initiating a connection, it only
controls what connections will be accepted by an asio server (hence not
a security issue in cpp-pcp-client). However, since we specify
`no_sslv2` it seems clearer to also specify `no_sslv3` to be
unambiguous.