### PR TITLE
(maint) Extend timeout for unit test to associate

### DIFF
--- a/lib/tests/unit/connector/connection_test.cc
+++ b/lib/tests/unit/connector/connection_test.cc
@@ -35,7 +35,7 @@ static void let_connection_stop(Connection const& connection, int timeout = 2)
     REQUIRE(connection.getConnectionState() != ConnectionState::open);
 }
 
-static constexpr int TEST_TIMEOUT = 100;
+static constexpr int TEST_TIMEOUT = 1000;
 
 TEST_CASE("Connection::connect", "[connector]") {
     SECTION("successfully connects") {


### PR DESCRIPTION
Increase connection timeout to allow more time for connections to be
made on test hardware.