### PR TITLE
(maint) Add missing dependency for mock-server

### DIFF
--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -36,6 +36,7 @@ target_link_libraries(mock-server PRIVATE
     ${OPENSSL_SSL_LIBRARY}
     ${OPENSSL_CRYPTO_LIBRARY}
     ${PLATFORM_LIBS})
+add_dependencies(mock-server websocketpp)
 
 set(test_BIN cpp-pcp-client-unittests)
 add_executable(${test_BIN} ${SOURCES})


### PR DESCRIPTION
`mock_server.cc` contains an unrecognized dependency on `websocketpp`.
This can cause parallel builds to fail by trying to compile
`mock_server.cc` before `websocketpp` has been unpacked. Fix by adding
an explicit dependency between `websocketpp` and the `mock-server`
target.