### PR TITLE
(PCP-412) Update message to print target strings instead of numbers

### DIFF
--- a/lib/inc/cpp-pcp-client/connector/connection.hpp
+++ b/lib/inc/cpp-pcp-client/connector/connection.hpp
@@ -162,9 +162,9 @@ class LIBCPP_PCP_CLIENT_EXPORT Connection {
     /// Defaults to 0, and increments when a successful
     /// connection and the first reconnect attempt against that
     /// connection fail, or when an attempt to connect to a new
-    /// broker fails. This value module size of the broker list
+    /// broker fails. This value modulo size of the broker list
     /// identifies the current broker to target.
-    std::atomic<size_t> connection_target_;
+    std::atomic<size_t> connection_target_index_;
 
     /// Consecutive pong timeouts counter (NB: useful for debug msgs)
     uint32_t consecutive_pong_timeouts_ { 0 };

--- a/lib/src/connector/connection.cc
+++ b/lib/src/connector/connection.cc
@@ -65,7 +65,7 @@ Connection::Connection(std::vector<std::string> broker_ws_uris,
         : broker_ws_uris_ { std::move(broker_ws_uris) },
           client_metadata_ { std::move(client_metadata) },
           connection_state_ { ConnectionState::initialized },
-          connection_target_ { 0u },
+          connection_target_index_ { 0u },
           consecutive_pong_timeouts_ { 0 },
           endpoint_ { new WS_Client_Type() }
 {
@@ -333,14 +333,14 @@ void Connection::connect_() {
 }
 
 std::string const& Connection::getWsUri() {
-    auto c_t = connection_target_.load();
+    auto c_t = connection_target_index_.load();
     return broker_ws_uris_[c_t % broker_ws_uris_.size()];
 }
 
 void Connection::switchWsUri() {
-    auto old_t = connection_target_.load();
-    ++connection_target_;
-    auto current_t = connection_target_.load();
+    auto old_t = getWsUri();
+    ++connection_target_index_;
+    auto current_t = getWsUri();
     if (old_t != current_t)
         LOG_WARNING("Failed to connect to {1}; switching to {2}",
                     old_t, current_t);


### PR DESCRIPTION
Updates to compare target URI strings, rather than their positions in
the URI list. Also prints out the URIs themselves rather than numbers.