### PR TITLE
(PCP-423) Close unresponsive connections

### DIFF
--- a/lib/inc/cpp-pcp-client/connector/client_metadata.hpp
+++ b/lib/inc/cpp-pcp-client/connector/client_metadata.hpp
@@ -22,6 +22,7 @@ class LIBCPP_PCP_CLIENT_EXPORT ClientMetadata {
     std::string uri;
     long ws_connection_timeout_ms;
     uint32_t association_timeout_s;
+    uint32_t pong_timeouts_before_retry;
 
     /// Throws a connection_config_error in case: the client
     /// certificate file does not exist or is invalid; it fails to
@@ -32,7 +33,8 @@ class LIBCPP_PCP_CLIENT_EXPORT ClientMetadata {
                    std::string _crt,
                    std::string _key,
                    long _ws_connection_timeout_ms,
-                   uint32_t _association_timeout_s);
+                   uint32_t _association_timeout_s,
+                   uint32_t _pong_timeouts_before_retry);
 };
 
 }  // namespace PCPClient

--- a/lib/inc/cpp-pcp-client/connector/connector.hpp
+++ b/lib/inc/cpp-pcp-client/connector/connector.hpp
@@ -43,7 +43,8 @@ class LIBCPP_PCP_CLIENT_EXPORT Connector {
               std::string client_crt_path,
               std::string client_key_path,
               long ws_connection_timeout_ms = 5000,
-              uint32_t association_timeout_s = 10);
+              uint32_t association_timeout_s = 10,
+              uint32_t pong_timeouts_before_retry = 3);
 
     Connector(std::vector<std::string> broker_ws_uris,
               std::string client_type,
@@ -51,7 +52,8 @@ class LIBCPP_PCP_CLIENT_EXPORT Connector {
               std::string client_crt_path,
               std::string client_key_path,
               long ws_connection_timeout = 5000,
-              uint32_t association_timeout_s = 10);
+              uint32_t association_timeout_s = 10,
+              uint32_t pong_timeouts_before_retry = 3);
 
     ~Connector();
 

--- a/lib/src/connector/client_metadata.cc
+++ b/lib/src/connector/client_metadata.cc
@@ -109,7 +109,8 @@ ClientMetadata::ClientMetadata(std::string _client_type,
                                std::string _crt,
                                std::string _key,
                                long _ws_connection_timeout_ms,
-                               uint32_t _association_timeout_s)
+                               uint32_t _association_timeout_s,
+                               uint32_t _pong_timeouts_before_retry)
         : ca { std::move(_ca) },
           crt { std::move(_crt) },
           key { std::move(_key) },
@@ -117,7 +118,8 @@ ClientMetadata::ClientMetadata(std::string _client_type,
           common_name { getCommonNameFromCert(crt) },
           uri { PCP_URI_SCHEME + common_name + "/" + client_type },
           ws_connection_timeout_ms { std::move(_ws_connection_timeout_ms) },
-          association_timeout_s { std::move(_association_timeout_s) }
+          association_timeout_s { std::move(_association_timeout_s) },
+          pong_timeouts_before_retry { std::move(_pong_timeouts_before_retry) }
 {
     LOG_INFO("Retrieved common name from the certificate and determined "
              "the client URI: {1}", uri);

--- a/lib/src/connector/connector.cc
+++ b/lib/src/connector/connector.cc
@@ -46,14 +46,16 @@ Connector::Connector(std::string broker_ws_uri,
                      std::string client_crt_path,
                      std::string client_key_path,
                      long ws_connection_timeout_ms,
-                     uint32_t association_timeout_s)
+                     uint32_t association_timeout_s,
+                     uint32_t pong_timeouts_before_retry)
         : Connector { std::vector<std::string> { std::move(broker_ws_uri) },
                       std::move(client_type),
                       std::move(ca_crt_path),
                       std::move(client_crt_path),
                       std::move(client_key_path),
                       std::move(ws_connection_timeout_ms),
-                      std::move(association_timeout_s) }
+                      std::move(association_timeout_s),
+                      std::move(pong_timeouts_before_retry) }
 {
 }
 
@@ -63,14 +65,16 @@ Connector::Connector(std::vector<std::string> broker_ws_uris,
                      std::string client_crt_path,
                      std::string client_key_path,
                      long ws_connection_timeout_ms,
-                     uint32_t association_timeout_s)
+                     uint32_t association_timeout_s,
+                     uint32_t pong_timeouts_before_retry)
         : broker_ws_uris_ { std::move(broker_ws_uris) },
           client_metadata_ { std::move(client_type),
                              std::move(ca_crt_path),
                              std::move(client_crt_path),
                              std::move(client_key_path),
                              std::move(ws_connection_timeout_ms),
-                             std::move(association_timeout_s) },
+                             std::move(association_timeout_s),
+                             std::move(pong_timeouts_before_retry) },
           connection_ptr_ { nullptr },
           validator_ {},
           schema_callback_pairs_ {},

--- a/lib/tests/unit/connector/client_metadata_test.cc
+++ b/lib/tests/unit/connector/client_metadata_test.cc
@@ -29,12 +29,13 @@ TEST_CASE("validatePrivateKeyCertPair", "[connector]") {
 
 static constexpr int WS_TIMEOUT { 5000 };
 static constexpr uint32_t ASSOCIATION_TIMEOUT { 10 };
+static constexpr uint32_t PONG_TIMEOUTS_BEFORE_RETRY { 3 };
 
 TEST_CASE("ClientMetadata::ClientMetadata", "[connector]") {
     SECTION("retrieves correctly the client common name from the certificate") {
         std::string type { "test" };
         ClientMetadata c_m { type, getCaPath(), getCertPath(), getKeyPath(),
-                             WS_TIMEOUT, ASSOCIATION_TIMEOUT };
+                             WS_TIMEOUT, ASSOCIATION_TIMEOUT, PONG_TIMEOUTS_BEFORE_RETRY };
 
         REQUIRE(c_m.common_name == "localhost");
     }
@@ -42,7 +43,7 @@ TEST_CASE("ClientMetadata::ClientMetadata", "[connector]") {
     SECTION("determines correctly the client URI") {
         std::string type { "test" };
         ClientMetadata c_m { type, getCaPath(), getCertPath(), getKeyPath(),
-                             WS_TIMEOUT, ASSOCIATION_TIMEOUT };
+                             WS_TIMEOUT, ASSOCIATION_TIMEOUT, PONG_TIMEOUTS_BEFORE_RETRY };
         std::string expected_uri { "pcp://localhost/" + type };
 
         REQUIRE(c_m.uri == expected_uri);
@@ -52,7 +53,7 @@ TEST_CASE("ClientMetadata::ClientMetadata", "[connector]") {
             "file does not exist") {
         REQUIRE_THROWS_AS(ClientMetadata("test", getCaPath(),
                                          getNotExistentFilePath(), getKeyPath(),
-                                         WS_TIMEOUT, ASSOCIATION_TIMEOUT),
+                                         WS_TIMEOUT, ASSOCIATION_TIMEOUT, PONG_TIMEOUTS_BEFORE_RETRY),
                           connection_config_error);
     }
 
@@ -60,7 +61,7 @@ TEST_CASE("ClientMetadata::ClientMetadata", "[connector]") {
             "is invalid") {
         REQUIRE_THROWS_AS(ClientMetadata("test", getCaPath(), getNotACertPath(),
                                          getKeyPath(),
-                                         WS_TIMEOUT, ASSOCIATION_TIMEOUT),
+                                         WS_TIMEOUT, ASSOCIATION_TIMEOUT, PONG_TIMEOUTS_BEFORE_RETRY),
                           connection_config_error);
     }
 }

--- a/lib/tests/unit/connector/connection_test.cc
+++ b/lib/tests/unit/connector/connection_test.cc
@@ -15,12 +15,14 @@ namespace lth_util = leatherman::util;
 
 static constexpr int WS_TIMEOUT { 5000 };
 static constexpr uint32_t ASSOCIATION_TIMEOUT { 10 };
+static constexpr uint32_t PONG_TIMEOUTS_BEFORE_RETRY { 3 };
 
 TEST_CASE("Connection::connect errors", "[connector]") {
     SECTION("throws a connection_processing_error if the broker url is "
             "not a valid WebSocket url") {
         ClientMetadata c_m { "test_client", getCaPath(), getCertPath(),
-                             getKeyPath(), 6, ASSOCIATION_TIMEOUT };
+                             getKeyPath(), 6, ASSOCIATION_TIMEOUT,
+                             PONG_TIMEOUTS_BEFORE_RETRY };
         // NB: the dtor will wait for the 6 ms specified above
         Connection connection { "foo", c_m };
 
@@ -41,7 +43,8 @@ static void let_connection_stop(Connection const& connection, int timeout = 2)
 TEST_CASE("Connection::connect", "[connector]") {
     SECTION("successfully connects") {
         ClientMetadata c_m { "test_client", getCaPath(), getCertPath(),
-                             getKeyPath(), WS_TIMEOUT, ASSOCIATION_TIMEOUT };
+                             getKeyPath(), WS_TIMEOUT, ASSOCIATION_TIMEOUT,
+                             PONG_TIMEOUTS_BEFORE_RETRY };
 
         MockServer mock_server;
         bool connected = false;
@@ -61,7 +64,8 @@ TEST_CASE("Connection::connect", "[connector]") {
 
     SECTION("successfully connects to failover broker") {
         ClientMetadata c_m { "test_client", getCaPath(), getCertPath(),
-                             getKeyPath(), WS_TIMEOUT, ASSOCIATION_TIMEOUT };
+                             getKeyPath(), WS_TIMEOUT, ASSOCIATION_TIMEOUT,
+                             PONG_TIMEOUTS_BEFORE_RETRY };
 
         MockServer mock_server;
         bool connected = false;
@@ -84,7 +88,8 @@ TEST_CASE("Connection::connect", "[connector]") {
 
     SECTION("successfully connects to failover when primary broker disappears") {
         ClientMetadata c_m { "test_client", getCaPath(), getCertPath(),
-                             getKeyPath(), WS_TIMEOUT, ASSOCIATION_TIMEOUT };
+                             getKeyPath(), WS_TIMEOUT, ASSOCIATION_TIMEOUT,
+                             PONG_TIMEOUTS_BEFORE_RETRY };
 
         bool connected_a = false, connected_b = false, connected_c = false;
 
@@ -136,7 +141,8 @@ TEST_CASE("Connection::~Connection", "[connector]") {
     mock_server.go();
 
     ClientMetadata c_m { "test_client", getCaPath(), getCertPath(),
-                         getKeyPath(), WS_TIMEOUT, ASSOCIATION_TIMEOUT };
+                         getKeyPath(), WS_TIMEOUT, ASSOCIATION_TIMEOUT,
+                         PONG_TIMEOUTS_BEFORE_RETRY };
 
     SECTION("connecting with a single attempt") {
         SECTION("connection timeout = 1 ms") {

--- a/locales/cpp-pcp-client.pot
+++ b/locales/cpp-pcp-client.pot
@@ -58,13 +58,13 @@ msgid "failed to retrieve the client common name from '{1}'"
 msgstr ""
 
 #. info
-#: lib/src/connector/client_metadata.cc:122
+#: lib/src/connector/client_metadata.cc:124
 msgid ""
 "Retrieved common name from the certificate and determined the client URI: {1}"
 msgstr ""
 
 #. debug
-#: lib/src/connector/client_metadata.cc:125
+#: lib/src/connector/client_metadata.cc:127
 msgid "Validated the private key / certificate pair"
 msgstr ""
 
@@ -181,270 +181,282 @@ msgid "WebSocket onPong event"
 msgstr ""
 
 #. warning
-#: lib/src/connector/connection.cc:497
+#: lib/src/connector/connection.cc:499
+msgid ""
+"WebSocket onPongTimeout event ({1} consecutive); closing the WebSocket "
+"connection"
+msgstr ""
+
+#. warning
+#: lib/src/connector/connection.cc:503
+msgid "WebSocket onPongTimeout event"
+msgstr ""
+
+#. warning
+#: lib/src/connector/connection.cc:505
 msgid "WebSocket onPongTimeout event ({1} consecutive)"
 msgstr ""
 
 #. debug
-#: lib/src/connector/connection.cc:514
+#: lib/src/connector/connection.cc:523
 msgid "WebSocket on open event - {1}"
 msgstr ""
 
 #. info
-#: lib/src/connector/connection.cc:515
+#: lib/src/connector/connection.cc:524
 msgid ""
 "Successfully established a WebSocket connection with the PCP broker at {1}"
 msgstr ""
 
 #. error
-#: lib/src/connector/connection.cc:524
+#: lib/src/connector/connection.cc:533
 msgid "onOpen callback failure: {1}; closing the WebSocket connection"
 msgstr ""
 
 #. error
-#: lib/src/connector/connection.cc:527
+#: lib/src/connector/connection.cc:536
 msgid "onOpen callback failure; closing the WebSocket connection"
 msgstr ""
 
 #. error
-#: lib/src/connector/connection.cc:543
+#: lib/src/connector/connection.cc:552
 msgid "onMessage WebSocket callback failure: {1}"
 msgstr ""
 
 #. error
-#: lib/src/connector/connection.cc:545
+#: lib/src/connector/connection.cc:554
 msgid "onMessage WebSocket callback failure: unexpected error"
 msgstr ""
 
 #. info
-#: lib/src/connector/connector.cc:114
+#: lib/src/connector/connector.cc:118
 msgid "Resetting the WebSocket event callbacks"
 msgstr ""
 
 #. debug
-#: lib/src/connector/connector.cc:178
+#: lib/src/connector/connector.cc:182
 msgid ""
 "There's an ongoing attempt to create a WebSocket connection; ensuring that "
 "it's closed before Associate Session"
 msgstr ""
 
 #. warning
-#: lib/src/connector/connector.cc:194
+#: lib/src/connector/connector.cc:198
 msgid "Unexpected - failed to close the WebSocket connection"
 msgstr ""
 
 #. warning
-#: lib/src/connector/connector.cc:200
+#: lib/src/connector/connector.cc:204
 msgid ""
 "WebSocket close failure ({1}); will continue with the Associate Session "
 "attempt"
 msgstr ""
 
 #. info
-#: lib/src/connector/connector.cc:227
+#: lib/src/connector/connector.cc:231
 msgid "Waiting for the PCP Session Association to complete"
 msgstr ""
 
 #. debug
-#: lib/src/connector/connector.cc:238
+#: lib/src/connector/connector.cc:242
 msgid "It seems that an error occurred during the Session Association ({1})"
 msgstr ""
 
-#: lib/src/connector/connector.cc:241
+#: lib/src/connector/connector.cc:245
 msgid "undetermined error"
 msgstr ""
 
-#: lib/src/connector/connector.cc:245
+#: lib/src/connector/connector.cc:249
 msgid "invalid Associate Session response"
 msgstr ""
 
 #. debug
-#: lib/src/connector/connector.cc:248
+#: lib/src/connector/connector.cc:252
 msgid "Associate Session timed out"
 msgstr ""
 
-#: lib/src/connector/connector.cc:251
+#: lib/src/connector/connector.cc:255
 msgid "operation timeout"
 msgstr ""
 
-#: lib/src/connector/connector.cc:254
+#: lib/src/connector/connector.cc:258
 msgid "Associate Session failure"
 msgstr ""
 
 #. debug
-#: lib/src/connector/connector.cc:267
+#: lib/src/connector/connector.cc:271
 msgid "Failed to establish the WebSocket connection: {1}"
 msgstr ""
 
 #. warning
-#: lib/src/connector/connector.cc:288
+#: lib/src/connector/connector.cc:292
 msgid "The monitorConnection function has already been called"
 msgstr ""
 
 #. debug
-#: lib/src/connector/connector.cc:297
+#: lib/src/connector/connector.cc:301
 msgid ""
 "Sending message of {1} bytes:\n"
 "{2}"
 msgstr ""
 
-#: lib/src/connector/connector.cc:365
+#: lib/src/connector/connector.cc:369
 msgid "connection not initialized"
 msgstr ""
 
 #. debug
-#: lib/src/connector/connector.cc:378
+#: lib/src/connector/connector.cc:382
 msgid "Creating message with id {1} for {2} receiver"
 msgstr ""
 
 #. debug
-#: lib/src/connector/connector.cc:381
+#: lib/src/connector/connector.cc:385
 msgid "Creating message with id {1} for {2} receivers"
 msgstr ""
 
 #. debug
-#: lib/src/connector/connector.cc:430
+#: lib/src/connector/connector.cc:434
 msgid ""
 "About to send Associate Session request; unexpectedly the Connector does not "
 "seem to be in the associating state"
 msgstr ""
 
 #. info
-#: lib/src/connector/connector.cc:448
+#: lib/src/connector/connector.cc:452
 msgid "Sending Associate Session request with id {1} and a TTL of {2} s"
 msgstr ""
 
 #. debug
-#: lib/src/connector/connector.cc:457
+#: lib/src/connector/connector.cc:461
 msgid ""
 "Received message of {1} bytes - raw message:\n"
 "{2}"
 msgstr ""
 
-#: lib/src/connector/connector.cc:468
+#: lib/src/connector/connector.cc:472
 msgid "Failed to deserialize message: {1}"
 msgstr ""
 
-#: lib/src/connector/connector.cc:478
+#: lib/src/connector/connector.cc:482
 msgid "Invalid envelope - bad content: {1}"
 msgstr ""
 
-#: lib/src/connector/connector.cc:480
+#: lib/src/connector/connector.cc:484
 msgid "Invalid envelope - invalid JSON content: {1}"
 msgstr ""
 
-#: lib/src/connector/connector.cc:484
+#: lib/src/connector/connector.cc:488
 msgid "Unknown schema: {1}"
 msgstr ""
 
 #. warning
-#: lib/src/connector/connector.cc:510
+#: lib/src/connector/connector.cc:514
 msgid "No message callback has be registered for the '{1}' schema"
 msgstr ""
 
 #. warning
-#: lib/src/connector/connector.cc:529
+#: lib/src/connector/connector.cc:533
 msgid "Received an unexpected Associate Session response; discarding it"
 msgstr ""
 
 #. warning
-#: lib/src/connector/connector.cc:535
+#: lib/src/connector/connector.cc:539
 msgid ""
 "Received an Associate Session response that refers to an unknown request ID "
 "({1}, expected {2}); discarding it"
 msgstr ""
 
-#: lib/src/connector/connector.cc:541
+#: lib/src/connector/connector.cc:545
 msgid "Received an Associate Session response {1} from {2} for the request {3}"
 msgstr ""
 
 #. info
-#: lib/src/connector/connector.cc:546
+#: lib/src/connector/connector.cc:550
 msgid "{1}: success"
 msgstr ""
 
 #. warning
-#: lib/src/connector/connector.cc:550
+#: lib/src/connector/connector.cc:554
 msgid "{1}: failure - {2}"
 msgstr ""
 
 #. warning
-#: lib/src/connector/connector.cc:553
+#: lib/src/connector/connector.cc:557
 msgid "{1}: failure"
 msgstr ""
 
-#: lib/src/connector/connector.cc:577
+#: lib/src/connector/connector.cc:581
 msgid "Received error {1} from {2}"
 msgstr ""
 
 #. warning
-#: lib/src/connector/connector.cc:582
+#: lib/src/connector/connector.cc:586
 msgid "{1} caused by message {2}: {3}"
 msgstr ""
 
 #. warning
-#: lib/src/connector/connector.cc:584
+#: lib/src/connector/connector.cc:588
 msgid "{1} (the id of the message that caused it is unknown): {2}"
 msgstr ""
 
 #. debug
-#: lib/src/connector/connector.cc:595
+#: lib/src/connector/connector.cc:599
 msgid "The error message {1} is due to the Associate Session request {2}"
 msgstr ""
 
 #. warning
-#: lib/src/connector/connector.cc:615
+#: lib/src/connector/connector.cc:619
 msgid "Received TTL Expired message {1} from {2} related to message {3}"
 msgstr ""
 
 #. debug
-#: lib/src/connector/connector.cc:627
+#: lib/src/connector/connector.cc:631
 msgid ""
 "The TTL expired message {1} is related to the Associate Session request {2}"
 msgstr ""
 
 #. info
-#: lib/src/connector/connector.cc:642
+#: lib/src/connector/connector.cc:646
 msgid "Starting the monitor task"
 msgstr ""
 
 #. warning
-#: lib/src/connector/connector.cc:658
+#: lib/src/connector/connector.cc:662
 msgid "WebSocket connection to PCP broker lost; retrying"
 msgstr ""
 
 #. debug
-#: lib/src/connector/connector.cc:661
+#: lib/src/connector/connector.cc:665
 msgid "Sending heartbeat ping"
 msgstr ""
 
 #. warning
-#: lib/src/connector/connector.cc:667
+#: lib/src/connector/connector.cc:671
 msgid ""
 "The connection monitor task will continue after a WebSocket failure ({1})"
 msgstr ""
 
 #. warning
-#: lib/src/connector/connector.cc:671
+#: lib/src/connector/connector.cc:675
 msgid ""
 "The connection monitor task will continue after an error during the Session "
 "Association ({1})"
 msgstr ""
 
 #. warning
-#: lib/src/connector/connector.cc:675
+#: lib/src/connector/connector.cc:679
 msgid ""
 "The connection monitor task will stop after an Session Association failure: "
 "{1}"
 msgstr ""
 
 #. warning
-#: lib/src/connector/connector.cc:681
+#: lib/src/connector/connector.cc:685
 msgid "The connection monitor task will stop: {1}"
 msgstr ""
 
 #. info
-#: lib/src/connector/connector.cc:687
+#: lib/src/connector/connector.cc:691
 msgid "Stopping the monitor task"
 msgstr ""
 


### PR DESCRIPTION
If several consecutive pong responses to pings time out - the number is
configurable - the connection will be closed. This allows fail over to
other brokers if the connected broker becomes unresponsive. Otherwise
the client would never attempt to disconnect from an unresponsive
broker.

P.S. I'm not really sure how to unit test this type of dropped connection.