### PR TITLE
(PCP-452) Configure timeout for whole Association process

### DIFF
--- a/lib/inc/cpp-pcp-client/connector/client_metadata.hpp
+++ b/lib/inc/cpp-pcp-client/connector/client_metadata.hpp
@@ -22,7 +22,9 @@ class LIBCPP_PCP_CLIENT_EXPORT ClientMetadata {
     std::string uri;
     long ws_connection_timeout_ms;
     uint32_t association_timeout_s;
+    uint32_t association_request_ttl_s;
     uint32_t pong_timeouts_before_retry;
+    long pong_timeout_ms;
 
     /// Throws a connection_config_error in case: the client
     /// certificate file does not exist or is invalid; it fails to
@@ -34,7 +36,9 @@ class LIBCPP_PCP_CLIENT_EXPORT ClientMetadata {
                    std::string _key,
                    long _ws_connection_timeout_ms,
                    uint32_t _association_timeout_s,
-                   uint32_t _pong_timeouts_before_retry);
+                   uint32_t _association_request_ttl_s,
+                   uint32_t _pong_timeouts_before_retry,
+                   long _pong_timeout_ms = 30);
 };
 
 }  // namespace PCPClient

--- a/lib/inc/cpp-pcp-client/connector/connector.hpp
+++ b/lib/inc/cpp-pcp-client/connector/connector.hpp
@@ -43,17 +43,21 @@ class LIBCPP_PCP_CLIENT_EXPORT Connector {
               std::string client_crt_path,
               std::string client_key_path,
               long ws_connection_timeout_ms = 5000,
-              uint32_t association_timeout_s = 10,
-              uint32_t pong_timeouts_before_retry = 3);
+              uint32_t association_timeout_s = 15,
+              uint32_t association_request_ttl_s = 10,
+              uint32_t pong_timeouts_before_retry = 3,
+              long ws_pong_timeout_ms = 30000);
 
     Connector(std::vector<std::string> broker_ws_uris,
               std::string client_type,
               std::string ca_crt_path,
               std::string client_crt_path,
               std::string client_key_path,
-              long ws_connection_timeout = 5000,
-              uint32_t association_timeout_s = 10,
-              uint32_t pong_timeouts_before_retry = 3);
+              long ws_connection_timeout_ms = 5000,
+              uint32_t association_timeout_s = 15,
+              uint32_t association_request_ttl_s = 10,
+              uint32_t pong_timeouts_before_retry = 3,
+              long ws_pong_timeout_ms = 30000);
 
     ~Connector();
 

--- a/lib/src/connector/client_metadata.cc
+++ b/lib/src/connector/client_metadata.cc
@@ -110,7 +110,9 @@ ClientMetadata::ClientMetadata(std::string _client_type,
                                std::string _key,
                                long _ws_connection_timeout_ms,
                                uint32_t _association_timeout_s,
-                               uint32_t _pong_timeouts_before_retry)
+                               uint32_t _association_request_ttl_s,
+                               uint32_t _pong_timeouts_before_retry,
+                               long _pong_timeout_ms)
         : ca { std::move(_ca) },
           crt { std::move(_crt) },
           key { std::move(_key) },
@@ -119,7 +121,9 @@ ClientMetadata::ClientMetadata(std::string _client_type,
           uri { PCP_URI_SCHEME + common_name + "/" + client_type },
           ws_connection_timeout_ms { std::move(_ws_connection_timeout_ms) },
           association_timeout_s { std::move(_association_timeout_s) },
-          pong_timeouts_before_retry { std::move(_pong_timeouts_before_retry) }
+          association_request_ttl_s { std::move(_association_request_ttl_s) },
+          pong_timeouts_before_retry { std::move(_pong_timeouts_before_retry) },
+          pong_timeout_ms { std::move(_pong_timeout_ms) }
 {
     LOG_INFO("Retrieved common name from the certificate and determined "
              "the client URI: {1}", uri);

--- a/lib/tests/unit/connector/client_metadata_test.cc
+++ b/lib/tests/unit/connector/client_metadata_test.cc
@@ -28,14 +28,16 @@ TEST_CASE("validatePrivateKeyCertPair", "[connector]") {
 }
 
 static constexpr int WS_TIMEOUT { 5000 };
-static constexpr uint32_t ASSOCIATION_TIMEOUT { 10 };
+static constexpr uint32_t ASSOCIATION_TIMEOUT_S { 15 };
+static constexpr uint32_t ASSOCIATION_REQUEST_TTL_S { 10 };
 static constexpr uint32_t PONG_TIMEOUTS_BEFORE_RETRY { 3 };
 
 TEST_CASE("ClientMetadata::ClientMetadata", "[connector]") {
     SECTION("retrieves correctly the client common name from the certificate") {
         std::string type { "test" };
         ClientMetadata c_m { type, getCaPath(), getCertPath(), getKeyPath(),
-                             WS_TIMEOUT, ASSOCIATION_TIMEOUT, PONG_TIMEOUTS_BEFORE_RETRY };
+                             WS_TIMEOUT, ASSOCIATION_TIMEOUT_S,
+                             ASSOCIATION_REQUEST_TTL_S, PONG_TIMEOUTS_BEFORE_RETRY };
 
         REQUIRE(c_m.common_name == "localhost");
     }
@@ -43,7 +45,8 @@ TEST_CASE("ClientMetadata::ClientMetadata", "[connector]") {
     SECTION("determines correctly the client URI") {
         std::string type { "test" };
         ClientMetadata c_m { type, getCaPath(), getCertPath(), getKeyPath(),
-                             WS_TIMEOUT, ASSOCIATION_TIMEOUT, PONG_TIMEOUTS_BEFORE_RETRY };
+                             WS_TIMEOUT, ASSOCIATION_TIMEOUT_S,
+                             ASSOCIATION_REQUEST_TTL_S, PONG_TIMEOUTS_BEFORE_RETRY };
         std::string expected_uri { "pcp://localhost/" + type };
 
         REQUIRE(c_m.uri == expected_uri);
@@ -53,7 +56,9 @@ TEST_CASE("ClientMetadata::ClientMetadata", "[connector]") {
             "file does not exist") {
         REQUIRE_THROWS_AS(ClientMetadata("test", getCaPath(),
                                          getNotExistentFilePath(), getKeyPath(),
-                                         WS_TIMEOUT, ASSOCIATION_TIMEOUT, PONG_TIMEOUTS_BEFORE_RETRY),
+                                         WS_TIMEOUT, ASSOCIATION_TIMEOUT_S,
+                                         ASSOCIATION_REQUEST_TTL_S,
+                                         PONG_TIMEOUTS_BEFORE_RETRY),
                           connection_config_error);
     }
 
@@ -61,7 +66,9 @@ TEST_CASE("ClientMetadata::ClientMetadata", "[connector]") {
             "is invalid") {
         REQUIRE_THROWS_AS(ClientMetadata("test", getCaPath(), getNotACertPath(),
                                          getKeyPath(),
-                                         WS_TIMEOUT, ASSOCIATION_TIMEOUT, PONG_TIMEOUTS_BEFORE_RETRY),
+                                         WS_TIMEOUT, ASSOCIATION_TIMEOUT_S,
+                                         ASSOCIATION_REQUEST_TTL_S,
+                                         PONG_TIMEOUTS_BEFORE_RETRY),
                           connection_config_error);
     }
 }

--- a/lib/tests/unit/connector/connection_test.cc
+++ b/lib/tests/unit/connector/connection_test.cc
@@ -14,15 +14,16 @@ namespace PCPClient {
 namespace lth_util = leatherman::util;
 
 static constexpr int WS_TIMEOUT { 5000 };
-static constexpr uint32_t ASSOCIATION_TIMEOUT { 10 };
+static constexpr uint32_t ASSOCIATION_TIMEOUT_S { 15 };
+static constexpr uint32_t ASSOCIATION_REQUEST_TTL_S { 10 };
 static constexpr uint32_t PONG_TIMEOUTS_BEFORE_RETRY { 3 };
 
 TEST_CASE("Connection::connect errors", "[connector]") {
     SECTION("throws a connection_processing_error if the broker url is "
             "not a valid WebSocket url") {
         ClientMetadata c_m { "test_client", getCaPath(), getCertPath(),
-                             getKeyPath(), 6, ASSOCIATION_TIMEOUT,
-                             PONG_TIMEOUTS_BEFORE_RETRY };
+                             getKeyPath(), 6, ASSOCIATION_TIMEOUT_S,
+                             ASSOCIATION_REQUEST_TTL_S, PONG_TIMEOUTS_BEFORE_RETRY };
         // NB: the dtor will wait for the 6 ms specified above
         Connection connection { "foo", c_m };
 
@@ -43,8 +44,8 @@ static void let_connection_stop(Connection const& connection, int timeout = 2)
 TEST_CASE("Connection::connect", "[connector]") {
     SECTION("successfully connects") {
         ClientMetadata c_m { "test_client", getCaPath(), getCertPath(),
-                             getKeyPath(), WS_TIMEOUT, ASSOCIATION_TIMEOUT,
-                             PONG_TIMEOUTS_BEFORE_RETRY };
+                             getKeyPath(), WS_TIMEOUT, ASSOCIATION_TIMEOUT_S,
+                             ASSOCIATION_REQUEST_TTL_S, PONG_TIMEOUTS_BEFORE_RETRY };
 
         MockServer mock_server;
         bool connected = false;
@@ -64,8 +65,8 @@ TEST_CASE("Connection::connect", "[connector]") {
 
     SECTION("successfully connects to failover broker") {
         ClientMetadata c_m { "test_client", getCaPath(), getCertPath(),
-                             getKeyPath(), WS_TIMEOUT, ASSOCIATION_TIMEOUT,
-                             PONG_TIMEOUTS_BEFORE_RETRY };
+                             getKeyPath(), WS_TIMEOUT, ASSOCIATION_TIMEOUT_S,
+                             ASSOCIATION_REQUEST_TTL_S, PONG_TIMEOUTS_BEFORE_RETRY };
 
         MockServer mock_server;
         bool connected = false;
@@ -88,8 +89,8 @@ TEST_CASE("Connection::connect", "[connector]") {
 
     SECTION("successfully connects to failover when primary broker disappears") {
         ClientMetadata c_m { "test_client", getCaPath(), getCertPath(),
-                             getKeyPath(), WS_TIMEOUT, ASSOCIATION_TIMEOUT,
-                             PONG_TIMEOUTS_BEFORE_RETRY };
+                             getKeyPath(), WS_TIMEOUT, ASSOCIATION_TIMEOUT_S,
+                             ASSOCIATION_REQUEST_TTL_S, PONG_TIMEOUTS_BEFORE_RETRY };
 
         bool connected_a = false, connected_b = false, connected_c = false;
 
@@ -141,8 +142,8 @@ TEST_CASE("Connection::~Connection", "[connector]") {
     mock_server.go();
 
     ClientMetadata c_m { "test_client", getCaPath(), getCertPath(),
-                         getKeyPath(), WS_TIMEOUT, ASSOCIATION_TIMEOUT,
-                         PONG_TIMEOUTS_BEFORE_RETRY };
+                         getKeyPath(), WS_TIMEOUT, ASSOCIATION_TIMEOUT_S,
+                         ASSOCIATION_REQUEST_TTL_S, PONG_TIMEOUTS_BEFORE_RETRY };
 
     SECTION("connecting with a single attempt") {
         SECTION("connection timeout = 1 ms") {


### PR DESCRIPTION
Allow configuring the overall timeout for the Association process in
addition to the Association request ttl.