### PR TITLE
(PCP-455) Connector unit tests

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -56,13 +56,7 @@ add_dependencies(libcpp-pcp-client websocketpp valijson)
 target_link_libraries(libcpp-pcp-client PRIVATE ${LIBS} ${PLATFORM_LIBS})
 
 # Generate the export header
-include(GenerateExportHeader)
-generate_export_header(libcpp-pcp-client EXPORT_FILE_NAME "${CMAKE_CURRENT_LIST_DIR}/inc/cpp-pcp-client/export.h")
-target_compile_definitions(libcpp-pcp-client PRIVATE -Dlibcpp_pcp_client_EXPORTS)
-
-if ((NOT APPLE) AND (NOT CMAKE_SYSTEM_NAME MATCHES "AIX") AND BUILD_SHARED_LIBS)
-    set_target_properties(libcpp-pcp-client PROPERTIES VISIBILITY_INLINES_HIDDEN ON)
-endif()
+symbol_exports(libcpp-pcp-client "${CMAKE_CURRENT_LIST_DIR}/inc/cpp-pcp-client/export.h")
 
 leatherman_install(libcpp-pcp-client)
 install(DIRECTORY inc/cpp-pcp-client DESTINATION include)

--- a/lib/inc/cpp-pcp-client/connector/connector.hpp
+++ b/lib/inc/cpp-pcp-client/connector/connector.hpp
@@ -126,12 +126,14 @@ class LIBCPP_PCP_CLIENT_EXPORT Connector {
     bool isAssociated() const;
 
     /// Starts the monitoring task in a separate thread.
-    //  Such task will periodically check the state of the
-    //  underlying connection and re-establish it in case it has
-    //  dropped, otherwise it will send a WebSocket ping to the
-    //  current broker in to keep the connection alive.
-    /// The max_connect_attempts parameters is used to reconnect;
-    /// it works as for the above connect() function.
+    /// Such task will periodically check the state of the
+    /// underlying connection and re-establish it in case it has
+    /// dropped, otherwise it will send a WebSocket ping to the
+    /// current broker in to keep the connection alive.
+    /// The check period is specified by connection_check_interval_s
+    /// (optional, in seconds).
+    /// The max_connect_attempts parameters is used to reconnect
+    /// (optional); it works as for the above connect() function.
     ///
     /// Note that monitorConnection simply returns in case of multiple
     /// calls.
@@ -144,7 +146,8 @@ class LIBCPP_PCP_CLIENT_EXPORT Connector {
     /// specified maximum number of attempts.
     /// Throws a connection_not_init_error in case the connection has
     /// not been opened previously.
-    void startMonitoring(int max_connect_attempts = 0);
+    void startMonitoring(const uint32_t max_connect_attempts = 0,
+                         const uint32_t connection_check_interval_s = 15);
 
     /// Stops the monitoring task in case it's running, otherwise the
     /// function simply logs a warning.
@@ -281,7 +284,8 @@ class LIBCPP_PCP_CLIENT_EXPORT Connector {
     // Monitor the underlying connection; reconnect or keep it alive.
     // If the underlying connection is dropped, unset the
     // is_associated_ flag.
-    void startMonitorTask(int max_connect_attempts);
+    void startMonitorTask(const uint32_t max_connect_attempts,
+                          const uint32_t connection_check_interval_s);
 
     // Stop the monitoring thread and wait for it to terminate.
     void stopMonitorTaskAndWait();

--- a/lib/inc/cpp-pcp-client/protocol/schemas.hpp
+++ b/lib/inc/cpp-pcp-client/protocol/schemas.hpp
@@ -12,7 +12,7 @@ namespace Protocol {
 //
 
 static const std::string ENVELOPE_SCHEMA_NAME { "envelope_schema" };
-Schema EnvelopeSchema();
+LIBCPP_PCP_CLIENT_EXPORT Schema EnvelopeSchema();
 
 //
 // data

--- a/lib/src/connector/connection.cc
+++ b/lib/src/connector/connection.cc
@@ -81,6 +81,7 @@ Connection::Connection(std::vector<std::string> broker_ws_uris,
     endpoint_->start_perpetual();
 
     try {
+        // Handlers
         endpoint_->set_tls_init_handler(
             std::bind(&Connection::onTlsInit, this, std::placeholders::_1));
         endpoint_->set_open_handler(
@@ -105,6 +106,9 @@ Connection::Connection(std::vector<std::string> broker_ws_uris,
             std::bind(&Connection::onPreTCPInit, this, std::placeholders::_1));
         endpoint_->set_tcp_post_init_handler(
             std::bind(&Connection::onPostTCPInit, this, std::placeholders::_1));
+
+        // Pong timeout
+        endpoint_->set_pong_timeout(client_metadata_.pong_timeout_ms);
 
         // Start the event loop thread
         endpoint_thread_.reset(new Util::thread(&WS_Client_Type::run, endpoint_.get()));

--- a/lib/src/connector/connector.cc
+++ b/lib/src/connector/connector.cc
@@ -120,7 +120,8 @@ Connector::Connector(std::vector<std::string> broker_ws_uris,
         });
 }
 
-Connector::~Connector() {
+Connector::~Connector()
+{
     if (connection_ptr_ != nullptr) {
         // reset callbacks to avoid breaking the Connection instance
         // due to callbacks having an invalid reference context
@@ -134,30 +135,35 @@ Connector::~Connector() {
 
 // Register schemas and onMessage callbacks
 void Connector::registerMessageCallback(const Schema& schema,
-                                        MessageCallback callback) {
+                                        MessageCallback callback)
+{
     validator_.registerSchema(schema);
     auto p = std::pair<std::string, MessageCallback>(schema.getName(), callback);
     schema_callback_pairs_.insert(p);
 }
 
 // Set an optional callback for error messages
-void Connector::setPCPErrorCallback(MessageCallback callback) {
+void Connector::setPCPErrorCallback(MessageCallback callback)
+{
     error_callback_ = callback;
 }
 
 // Set an optional callback for associate responses
-void Connector::setAssociateCallback(MessageCallback callback) {
+void Connector::setAssociateCallback(MessageCallback callback)
+{
     associate_response_callback_ = callback;
 }
 
 // Set an optional callback for TTL expired messages
-void Connector::setTTLExpiredCallback(MessageCallback callback) {
+void Connector::setTTLExpiredCallback(MessageCallback callback)
+{
     TTL_expired_callback_ = callback;
 }
 
 // Manage the connection state
 
-void Connector::connect(int max_connect_attempts) {
+void Connector::connect(int max_connect_attempts)
+{
     if (connection_ptr_ == nullptr) {
         // Initialize the WebSocket connection
         connection_ptr_.reset(new Connection(broker_ws_uris_, client_metadata_));
@@ -281,12 +287,14 @@ void Connector::connect(int max_connect_attempts) {
     }
 }
 
-bool Connector::isConnected() const {
+bool Connector::isConnected() const
+{
     return connection_ptr_ != nullptr
            && connection_ptr_->getConnectionState() == ConnectionState::open;
 }
 
-bool Connector::isAssociated() const {
+bool Connector::isAssociated() const
+{
     return isConnected() && session_association_.success.load();
 }
 
@@ -303,7 +311,8 @@ void Connector::startMonitoring(int max_connect_attempts) {
     }
 }
 
-void Connector::stopMonitoring() {
+void Connector::stopMonitoring()
+{
     checkConnectionInitialization();
 
     if (!is_monitoring_) {
@@ -315,7 +324,8 @@ void Connector::stopMonitoring() {
 
 // Send messages
 
-void Connector::send(const Message& msg) {
+void Connector::send(const Message& msg)
+{
     checkConnectionInitialization();
     auto serialized_msg = msg.getSerialized();
     LOG_DEBUG("Sending message of {1} bytes:\n{2}",
@@ -327,7 +337,8 @@ std::string Connector::send(const std::vector<std::string>& targets,
                      const std::string& message_type,
                      unsigned int timeout,
                      const lth_jc::JsonContainer& data_json,
-                     const std::vector<lth_jc::JsonContainer>& debug) {
+                     const std::vector<lth_jc::JsonContainer>& debug)
+{
     return sendMessage(targets,
                        message_type,
                        timeout,
@@ -340,7 +351,8 @@ std::string Connector::send(const std::vector<std::string>& targets,
                      const std::string& message_type,
                      unsigned int timeout,
                      const std::string& data_binary,
-                     const std::vector<lth_jc::JsonContainer>& debug) {
+                     const std::vector<lth_jc::JsonContainer>& debug)
+{
     return sendMessage(targets,
                        message_type,
                        timeout,
@@ -354,7 +366,8 @@ std::string Connector::send(const std::vector<std::string>& targets,
                      unsigned int timeout,
                      bool destination_report,
                      const lth_jc::JsonContainer& data_json,
-                     const std::vector<lth_jc::JsonContainer>& debug) {
+                     const std::vector<lth_jc::JsonContainer>& debug)
+{
     return sendMessage(targets,
                        message_type,
                        timeout,
@@ -368,7 +381,8 @@ std::string Connector::send(const std::vector<std::string>& targets,
                      unsigned int timeout,
                      bool destination_report,
                      const std::string& data_binary,
-                     const std::vector<lth_jc::JsonContainer>& debug) {
+                     const std::vector<lth_jc::JsonContainer>& debug)
+{
     return sendMessage(targets,
                        message_type,
                        timeout,
@@ -383,7 +397,8 @@ std::string Connector::send(const std::vector<std::string>& targets,
 
 // Utility functions
 
-void Connector::checkConnectionInitialization() {
+void Connector::checkConnectionInitialization()
+{
     if (connection_ptr_ == nullptr) {
         throw connection_not_init_error {
             lth_loc::translate("connection not initialized") };
@@ -394,7 +409,8 @@ MessageChunk Connector::createEnvelope(const std::vector<std::string>& targets,
                                        const std::string& message_type,
                                        unsigned int timeout,
                                        bool destination_report,
-                                       std::string& msg_id) {
+                                       std::string& msg_id)
+{
     msg_id = lth_util::get_UUID();
     auto expires = lth_util::get_ISO8601_time(timeout);
     // TODO(ale): deal with locale & plural (PCP-257)
@@ -426,7 +442,8 @@ std::string Connector::sendMessage(const std::vector<std::string>& targets,
                                    unsigned int timeout,
                                    bool destination_report,
                                    const std::string& data_txt,
-                                   const std::vector<lth_jc::JsonContainer>& debug) {
+                                   const std::vector<lth_jc::JsonContainer>& debug)
+{
     std::string msg_id {};
     auto envelope_chunk = createEnvelope(targets,
                                          message_type,
@@ -447,7 +464,8 @@ std::string Connector::sendMessage(const std::vector<std::string>& targets,
 
 // WebSocket onOpen callback - will send the associate session request
 
-void Connector::associateSession() {
+void Connector::associateSession()
+{
     Util::lock_guard<Util::mutex> the_lock { session_association_.mtx };
 
     if (!session_association_.in_progress.load())
@@ -476,7 +494,8 @@ void Connector::associateSession() {
 
 // WebSocket onMessage callback
 
-void Connector::processMessage(const std::string& msg_txt) {
+void Connector::processMessage(const std::string& msg_txt)
+{
 #ifdef DEV_LOG_RAW_MESSAGE
     LOG_DEBUG("Received message of {1} bytes - raw message:\n{2}",
               msg_txt.size(), msg_txt);
@@ -538,7 +557,8 @@ void Connector::processMessage(const std::string& msg_txt) {
 
 // Associate session response callback
 
-void Connector::associateResponseCallback(const ParsedChunks& parsed_chunks) {
+void Connector::associateResponseCallback(const ParsedChunks& parsed_chunks)
+{
     assert(parsed_chunks.has_data);
     assert(parsed_chunks.data_type == PCPClient::ContentType::Json);
 
@@ -589,7 +609,8 @@ void Connector::associateResponseCallback(const ParsedChunks& parsed_chunks) {
 
 // PCP error message callback
 
-void Connector::errorMessageCallback(const ParsedChunks& parsed_chunks) {
+void Connector::errorMessageCallback(const ParsedChunks& parsed_chunks)
+{
     assert(parsed_chunks.has_data);
     assert(parsed_chunks.data_type == PCPClient::ContentType::Json);
 
@@ -629,7 +650,8 @@ void Connector::errorMessageCallback(const ParsedChunks& parsed_chunks) {
 
 // ttl_expired message callback
 
-void Connector::TTLMessageCallback(const ParsedChunks& parsed_chunks) {
+void Connector::TTLMessageCallback(const ParsedChunks& parsed_chunks)
+{
     assert(parsed_chunks.has_data);
     assert(parsed_chunks.data_type == PCPClient::ContentType::Json);
 

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -8,6 +8,7 @@ set(SOURCES
     main.cc
     unit/connector/client_metadata_test.cc
     unit/connector/connection_test.cc
+    unit/connector/connector_test.cc
     unit/connector/certs.cc
     unit/protocol/serialization_test.cc
     unit/protocol/message_test.cc
@@ -18,6 +19,7 @@ set(SOURCES
 
 include_directories(
     ${LEATHERMAN_CATCH_INCLUDE}
+    ${VALIJSON_INCLUDE_DIRS}
 )
 
 if (WIN32)
@@ -29,14 +31,44 @@ endif()
 # described in https://gcc.gnu.org/ml/gcc-help/2015-08/msg00035.html, we get
 # the error undefined reference to symbol '__tls_get_addr@@GLIBC_2.3'.
 # Build mock_server as a separate shared library to avoid this error.
+
+if (LEATHERMAN_SHARED)
+    # Careful with the order, as done for libcpp-pcp-client
+    list(APPEND MOCK_SERVER_LIBS
+        ${Boost_REGEX_LIBRARY}
+        ${Boost_THREAD_LIBRARY}
+        ${Boost_SYSTEM_LIBRARY}
+        ${LEATHERMAN_LIBRARIES})
+else()
+    list(APPEND MOCK_SERVER_LIBS
+        ${LEATHERMAN_LIBRARIES}
+        ${Boost_REGEX_LIBRARY}
+        ${Boost_THREAD_LIBRARY}
+        ${Boost_SYSTEM_LIBRARY})
+endif()
+
+# pcp-chunk provides cpp-pcp-clients functions needed by MockServer
+add_library(pcp-chunks
+    ${SOURCE_DIR}/protocol/chunks.cc
+    ${SOURCE_DIR}/protocol/message.cc
+    ${SOURCE_DIR}/protocol/serialization.cc
+    ${SOURCE_DIR}/validator/schema.cc
+    ${SOURCE_DIR}/validator/validator.cc)
+target_link_libraries(pcp-chunks PRIVATE
+    ${MOCK_SERVER_LIBS}
+    ${PLATFORM_LIBS})
+add_dependencies(pcp-chunks valijson)
+# Add the libcpp-pcp-client export header
+target_compile_definitions(pcp-chunks PRIVATE -Dlibcpp_pcp_client_EXPORTS)
+
 add_library(mock-server unit/connector/mock_server.cc)
 target_link_libraries(mock-server PRIVATE
-    ${Boost_THREAD_LIBRARY}
-    ${Boost_SYSTEM_LIBRARY}
+    ${MOCK_SERVER_LIBS}
     ${OPENSSL_SSL_LIBRARY}
     ${OPENSSL_CRYPTO_LIBRARY}
-    ${PLATFORM_LIBS})
-add_dependencies(mock-server websocketpp)
+    ${PLATFORM_LIBS}
+    pcp-chunks)
+add_dependencies(mock-server pcp-chunks websocketpp)
 
 set(test_BIN cpp-pcp-client-unittests)
 add_executable(${test_BIN} ${SOURCES})
@@ -48,7 +80,7 @@ add_executable(${test_BIN} ${SOURCES})
 # Ensure mock-server comes after libcpp-pcp-client, so it picks up libraries
 # compiled into libcpp-pcp-client. It comes after LIBS to avoid double
 # definition of boost::system::system_category() on Windows.
-target_link_libraries(${test_BIN} libcpp-pcp-client ${LIBS} mock-server)
+target_link_libraries(${test_BIN} libcpp-pcp-client ${LIBS} pcp-chunks mock-server)
 
 add_custom_target(check
     "${EXECUTABLE_OUTPUT_PATH}/${test_BIN}"

--- a/lib/tests/unit/connector/connector_test.cc
+++ b/lib/tests/unit/connector/connector_test.cc
@@ -1,0 +1,163 @@
+#include "tests/test.hpp"
+#include "tests/unit/connector/certs.hpp"
+#include "tests/unit/connector/mock_server.hpp"
+
+#include <cpp-pcp-client/connector/connector.hpp>
+#include <cpp-pcp-client/connector/client_metadata.hpp>
+#include <cpp-pcp-client/connector/errors.hpp>
+
+#include <cpp-pcp-client/util/chrono.hpp>
+
+#include <leatherman/util/timer.hpp>
+
+#include <memory>
+#include <atomic>
+#include <functional>
+
+namespace PCPClient {
+
+namespace lth_util = leatherman::util;
+
+static constexpr int WS_TIMEOUT_MS { 5000 };
+static constexpr uint32_t ASSOCIATION_TIMEOUT_S { 15 };
+static constexpr uint32_t ASSOCIATION_REQUEST_TTL_S { 10 };
+static constexpr uint32_t PONG_TIMEOUTS_BEFORE_RETRY { 3 };
+
+TEST_CASE("Connector::Connector", "[connector]") {
+    SECTION("can instantiate") {
+        REQUIRE_NOTHROW(Connector("wss://localhost:8142/pcp", "test_client",
+                                  getCaPath(), getCertPath(), getKeyPath(),
+                                  WS_TIMEOUT_MS,
+                                  ASSOCIATION_TIMEOUT_S, ASSOCIATION_REQUEST_TTL_S,
+                                  PONG_TIMEOUTS_BEFORE_RETRY));
+    }
+}
+
+static void wait_for(std::function<bool()> func, uint16_t pause_s = 2)
+{
+    lth_util::Timer timer {};
+
+    while (!func() && timer.elapsed_seconds() < pause_s)
+        Util::this_thread::sleep_for(Util::chrono::milliseconds(1));
+}
+
+TEST_CASE("Connector::connect", "[connector]") {
+    MockServer mock_server;
+    bool connected = false;
+    mock_server.set_open_handler(
+        [&connected](websocketpp::connection_hdl hdl) {
+            connected = true;
+        });
+    mock_server.go();
+    auto port = mock_server.port();
+
+    SECTION("successfully connects") {
+        Connector c { "wss://localhost:" + std::to_string(port) + "/pcp",
+                      "test_client",
+                      getCaPath(), getCertPath(), getKeyPath(),
+                      WS_TIMEOUT_MS, ASSOCIATION_TIMEOUT_S,
+                      ASSOCIATION_REQUEST_TTL_S, PONG_TIMEOUTS_BEFORE_RETRY };
+        REQUIRE_FALSE(connected);
+        REQUIRE_NOTHROW(c.connect(1));
+
+        // NB: Connector::connect is blocking
+        REQUIRE(c.isConnected());
+        REQUIRE(connected);
+
+        wait_for([&c](){return c.isAssociated();});
+
+        REQUIRE(c.isAssociated());
+    }
+}
+
+TEST_CASE("Connector::startMonitoring", "[connector]") {
+    SECTION("reconnects after the broker stops") {
+        std::unique_ptr<Connector> c_ptr;
+        uint16_t port;
+
+        {
+            MockServer mock_server;
+            bool connected = false;
+            mock_server.set_open_handler(
+                    [&connected](websocketpp::connection_hdl hdl) {
+                        connected = true;
+                    });
+            mock_server.go();
+            port = mock_server.port();
+
+            c_ptr.reset(new Connector("wss://localhost:" + std::to_string(port) + "/pcp",
+                                      "test_client",
+                                      getCaPath(), getCertPath(), getKeyPath(),
+                                      WS_TIMEOUT_MS, ASSOCIATION_TIMEOUT_S,
+                                      ASSOCIATION_REQUEST_TTL_S,
+                                      PONG_TIMEOUTS_BEFORE_RETRY));
+
+            REQUIRE_FALSE(connected);
+            REQUIRE_NOTHROW(c_ptr->connect(1));
+            REQUIRE(c_ptr->isConnected());
+            REQUIRE(connected);
+
+            // Infinite retries; 1 s between each WebSocket ping
+            REQUIRE_NOTHROW(c_ptr->startMonitoring(0, 1));
+        }
+
+        // The broker does not exist anymore (RAII)
+        wait_for([&c_ptr](){return !c_ptr->isConnected();});
+
+        REQUIRE_FALSE(c_ptr->isConnected());
+
+        MockServer mock_server {port};
+        mock_server.go();
+
+        wait_for([&c_ptr](){return c_ptr->isConnected();});
+
+        REQUIRE(c_ptr->isConnected());
+
+        wait_for([&c_ptr](){return c_ptr->isAssociated();});
+
+        REQUIRE(c_ptr->isAssociated());
+    }
+
+    SECTION("reconnects after 1 pong timeout") {
+        MockServer mock_server;
+        std::atomic<int> num_connections {0};
+        std::atomic<int> num_pings {0};
+        mock_server.set_open_handler(
+                [&num_connections](websocketpp::connection_hdl hdl) {
+                    ++num_connections;
+                });
+        mock_server.set_ping_handler(
+                [&num_pings](websocketpp::connection_hdl hdl, std::string) -> bool {
+                    ++num_pings;
+                    return false;
+                });
+        mock_server.go();
+        auto port = mock_server.port();
+
+        // Setting the pong timeout to 500 ms and the Association
+        // timeout to 1 s (Connector::connect will hang waiting for
+        // for the Association completion that won't happen because
+        // we'll be done as soon as num_connections > 1)
+        Connector c { "wss://localhost:" + std::to_string(port) + "/pcp",
+                      "test_client",
+                      getCaPath(), getCertPath(), getKeyPath(),
+                      WS_TIMEOUT_MS, 1, ASSOCIATION_REQUEST_TTL_S, 1, 500 };
+
+        REQUIRE(num_connections == 0);
+        REQUIRE(num_pings == 0);
+        REQUIRE_NOTHROW(c.connect(1));
+        REQUIRE(c.isConnected());
+        REQUIRE(num_connections == 1);
+
+        // Infinite retries; 1 s between each WebSocket ping
+        REQUIRE_NOTHROW(c.startMonitoring(0, 1));
+
+        // After 1 pong timeout, the Connector should close and reconnect
+        wait_for([&num_connections](){return num_connections > 1;}, 30);
+
+        REQUIRE(num_connections > 1);
+        REQUIRE(num_pings > 0);
+    }
+}
+
+}  // namespace PCPClient

--- a/lib/tests/unit/connector/mock_server.cc
+++ b/lib/tests/unit/connector/mock_server.cc
@@ -15,29 +15,57 @@
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
 #include <websocketpp/config/asio.hpp>
 #include <websocketpp/server.hpp>
+#include <websocketpp/common/connection_hdl.hpp>
 #pragma GCC diagnostic pop
 
 #include <cpp-pcp-client/util/thread.hpp>
+#include <cpp-pcp-client/protocol/schemas.hpp>
+#include <cpp-pcp-client/protocol/message.hpp>
+#include <cpp-pcp-client/protocol/errors.hpp>
+#include <cpp-pcp-client/protocol/chunks.hpp>
+
+#include <leatherman/json_container/json_container.hpp>
+
+#define LEATHERMAN_LOGGING_NAMESPACE CPP_PCP_CLIENT_LOGGING_PREFIX".mock_server"
+
+#include <leatherman/logging/logging.hpp>
+
+#include <iostream>
+#include <string>
 
 namespace PCPClient {
+
+namespace lth_jc  = leatherman::json_container;
 
 MockServer::MockServer(uint16_t port,
                        std::string certPath,
                        std::string keyPath)
-    : certPath_(std::move(certPath)), keyPath_(std::move(keyPath)), server_(new websocketpp::server<websocketpp::config::asio_tls>())
+    : certPath_(std::move(certPath)),
+      keyPath_(std::move(keyPath)),
+      server_(new websocketpp::server<websocketpp::config::asio_tls>())
 {
     namespace asio = websocketpp::lib::asio;
     server_->init_asio();
-    server_->set_tls_init_handler([&](websocketpp::connection_hdl hdl) {
-        auto ctx = websocketpp::lib::make_shared<asio::ssl::context>(asio::ssl::context::tlsv1);
-        ctx->set_options(asio::ssl::context::default_workarounds |
-                         asio::ssl::context::no_sslv2 |
-                         asio::ssl::context::no_sslv3 |
-                         asio::ssl::context::single_dh_use);
-        ctx->use_certificate_file(certPath_, asio::ssl::context::file_format::pem);
-        ctx->use_private_key_file(keyPath_, asio::ssl::context::file_format::pem);
-        return ctx;
-    });
+
+    server_->set_tls_init_handler(
+        [&](websocketpp::connection_hdl hdl) {
+            auto ctx = websocketpp::lib::make_shared<asio::ssl::context>(asio::ssl::context::tlsv1);
+            ctx->set_options(asio::ssl::context::default_workarounds |
+                             asio::ssl::context::no_sslv2 |
+                             asio::ssl::context::no_sslv3 |
+                             asio::ssl::context::single_dh_use);
+            ctx->use_certificate_file(certPath_, asio::ssl::context::file_format::pem);
+            ctx->use_private_key_file(keyPath_, asio::ssl::context::file_format::pem);
+            return ctx;
+        });
+
+    // Set the onMessage handler specifically for Association Requests
+    server_->set_message_handler(
+            std::bind(&MockServer::association_request_handler,
+                      this,
+                      std::placeholders::_1,
+                      std::placeholders::_2));
+
     server_->listen(port);
 }
 
@@ -63,6 +91,65 @@ uint16_t MockServer::port()
 void MockServer::set_open_handler(std::function<void(websocketpp::connection_hdl)> func)
 {
     server_->set_open_handler(func);
+}
+
+void MockServer::set_ping_handler(std::function<bool(websocketpp::connection_hdl, std::string)> func)
+{
+    server_->set_ping_handler(func);
+}
+
+//
+// Private
+//
+
+static const std::string MESSAGE_TYPE {"message_type"};
+static const std::string ID {"id"};
+static const std::string SUCCESS {"success"};
+
+void MockServer::association_request_handler
+        (websocketpp::connection_hdl hdl,
+         std::shared_ptr<
+            class websocketpp::message_buffer::message<
+                websocketpp::message_buffer::alloc::con_msg_manager>> req)
+{
+    try {
+        // Deserialize
+        Message request {req->get_payload()};
+
+        // Inspect envelope
+        lth_jc::JsonContainer env {request.getEnvelopeChunk().content};
+        auto message_type = env.get<std::string>(MESSAGE_TYPE);
+
+        if (message_type != Protocol::ASSOCIATE_REQ_TYPE) {
+            LOG_ERROR("Unknown message type: {1}", message_type);
+            return;
+        }
+
+        // Create the response message
+        env.set<std::string>(MESSAGE_TYPE, Protocol::ASSOCIATE_RESP_TYPE);
+        lth_jc::JsonContainer data {};
+        data.set<std::string>(ID, env.get<std::string>(ID));
+        env.set<std::string>(ID, "42424242");
+        data.set<bool>(SUCCESS, true);
+        auto data_txt = data.toString();
+        MessageChunk env_chunk  {ChunkDescriptor::ENVELOPE, env.toString()};
+        MessageChunk data_chunk {ChunkDescriptor::DATA, data_txt};
+        Message resp {env_chunk, data_chunk};
+        auto serialized_resp = resp.getSerialized();
+
+        server_->send(hdl,
+                      &serialized_resp[0],
+                      serialized_resp.size(),
+                      websocketpp::frame::opcode::binary);
+    } catch (const message_error& e) {
+        LOG_ERROR("Failed to deserialize message: {1}", e.what());
+        return;
+    } catch (const lth_jc::data_error&) {
+        LOG_ERROR("Invalid message (bad envelope)");
+        return;
+    } catch (const std::exception& e) {
+        LOG_ERROR("Failed to send the Association response: {1}", e.what());
+    }
 }
 
 }

--- a/lib/tests/unit/connector/mock_server.hpp
+++ b/lib/tests/unit/connector/mock_server.hpp
@@ -16,6 +16,16 @@ namespace websocketpp {
         struct asio_tls;
     }
 
+    namespace message_buffer {
+        namespace alloc {
+            template <typename message>
+            class con_msg_manager;
+        }
+
+        template <template<class> class con_msg_manager>
+        class message;
+    }
+
     using connection_hdl = std::weak_ptr<void>;
 }
 
@@ -33,10 +43,19 @@ public:
 
     void set_open_handler(std::function<void(websocketpp::connection_hdl)> func);
 
+    void set_ping_handler(std::function<bool(websocketpp::connection_hdl,
+                                             std::string)> func);
+
 private:
     std::string certPath_, keyPath_;
     std::unique_ptr<boost::thread> bt_;
     std::unique_ptr<websocketpp::server<websocketpp::config::asio_tls>> server_;
+
+    void association_request_handler(
+        websocketpp::connection_hdl hdl,
+        std::shared_ptr<
+            class websocketpp::message_buffer::message<
+                websocketpp::message_buffer::alloc::con_msg_manager>> req);
 };
 
 }

--- a/locales/cpp-pcp-client.pot
+++ b/locales/cpp-pcp-client.pot
@@ -58,420 +58,420 @@ msgid "failed to retrieve the client common name from '{1}'"
 msgstr ""
 
 #. info
-#: lib/src/connector/client_metadata.cc:124
+#: lib/src/connector/client_metadata.cc:128
 msgid ""
 "Retrieved common name from the certificate and determined the client URI: {1}"
 msgstr ""
 
 #. debug
-#: lib/src/connector/client_metadata.cc:127
+#: lib/src/connector/client_metadata.cc:131
 msgid "Validated the private key / certificate pair"
 msgstr ""
 
 #. debug
-#: lib/src/connector/connection.cc:112
+#: lib/src/connector/connection.cc:116
 msgid ""
 "Failed to configure the WebSocket endpoint; about to stop the event loop"
 msgstr ""
 
-#: lib/src/connector/connection.cc:115
+#: lib/src/connector/connection.cc:119
 msgid "failed to initialize"
 msgstr ""
 
 #. warning
-#: lib/src/connector/connection.cc:207
+#: lib/src/connector/connection.cc:211
 msgid "Failed to establish a WebSocket connection; retrying in {1} seconds"
 msgstr ""
 
-#: lib/src/connector/connection.cc:227
+#: lib/src/connector/connection.cc:231
 msgid "failed to establish a WebSocket connection after {1} attempt"
 msgstr ""
 
-#: lib/src/connector/connection.cc:228
+#: lib/src/connector/connection.cc:232
 msgid "failed to establish a WebSocket connection after {1} attempts"
 msgstr ""
 
-#: lib/src/connector/connection.cc:240
-#: lib/src/connector/connection.cc:252
+#: lib/src/connector/connection.cc:244
+#: lib/src/connector/connection.cc:256
 msgid "failed to send message: {1}"
 msgstr ""
 
-#: lib/src/connector/connection.cc:260
+#: lib/src/connector/connection.cc:264
 msgid "failed to send WebSocket ping: {1}"
 msgstr ""
 
 #. debug
-#: lib/src/connector/connection.cc:265
+#: lib/src/connector/connection.cc:269
 msgid "About to close the WebSocket connection"
 msgstr ""
 
-#: lib/src/connector/connection.cc:273
+#: lib/src/connector/connection.cc:277
 msgid "failed to close WebSocket connection: {1}"
 msgstr ""
 
 #. warning
-#: lib/src/connector/connection.cc:296
+#: lib/src/connector/connection.cc:300
 msgid "Cleanup failure: {1}"
 msgstr ""
 
 #. warning
-#: lib/src/connector/connection.cc:323
+#: lib/src/connector/connection.cc:327
 msgid "WebSocket in 'connecting' state; will try to close"
 msgstr ""
 
 #. warning
-#: lib/src/connector/connection.cc:330
+#: lib/src/connector/connection.cc:334
 msgid ""
 "Failed to close the WebSocket; will wait at most {1} ms before trying again"
 msgstr ""
 
-#: lib/src/connector/connection.cc:355
-#: lib/src/connector/connection.cc:367
+#: lib/src/connector/connection.cc:359
+#: lib/src/connector/connection.cc:371
 msgid "failed to establish the WebSocket connection with {1}: {2}"
 msgstr ""
 
 #. info
-#: lib/src/connector/connection.cc:359
+#: lib/src/connector/connection.cc:363
 msgid ""
 "Establishing the WebSocket connection with '{1}' with a timeout of {2} ms"
 msgstr ""
 
 #. warning
-#: lib/src/connector/connection.cc:382
+#: lib/src/connector/connection.cc:386
 msgid "Failed to connect to {1}; switching to {2}"
 msgstr ""
 
 #. debug
-#: lib/src/connector/connection.cc:404
+#: lib/src/connector/connection.cc:408
 msgid "Verifying {1}, issued by {2}. Verified: {3}"
 msgstr ""
 
 #. debug
-#: lib/src/connector/connection.cc:422
+#: lib/src/connector/connection.cc:426
 msgid "WebSocket TLS initialization event; about to validate the certificate"
 msgstr ""
 
 #. debug
-#: lib/src/connector/connection.cc:446
+#: lib/src/connector/connection.cc:450
 msgid "Initialized SSL context to verify broker {1}"
 msgstr ""
 
-#: lib/src/connector/connection.cc:451
+#: lib/src/connector/connection.cc:455
 msgid "TLS error: {1}"
 msgstr ""
 
 #. debug
-#: lib/src/connector/connection.cc:460
+#: lib/src/connector/connection.cc:464
 msgid "WebSocket on close event: {1} (code: {2}) - {3}"
 msgstr ""
 
 #. debug
-#: lib/src/connector/connection.cc:471
+#: lib/src/connector/connection.cc:475
 msgid "WebSocket on fail event - {1}"
 msgstr ""
 
 #. warning
-#: lib/src/connector/connection.cc:472
+#: lib/src/connector/connection.cc:476
 msgid "WebSocket on fail event (connection loss): {1} (code: {2})"
 msgstr ""
 
 #. debug
-#: lib/src/connector/connection.cc:484
+#: lib/src/connector/connection.cc:488
 msgid "WebSocket onPong event"
 msgstr ""
 
 #. warning
-#: lib/src/connector/connection.cc:494
+#: lib/src/connector/connection.cc:498
 msgid ""
 "WebSocket onPongTimeout event ({1} consecutive); closing the WebSocket "
 "connection"
 msgstr ""
 
 #. warning
-#: lib/src/connector/connection.cc:498
+#: lib/src/connector/connection.cc:502
 msgid "WebSocket onPongTimeout event"
 msgstr ""
 
 #. warning
-#: lib/src/connector/connection.cc:500
+#: lib/src/connector/connection.cc:504
 msgid "WebSocket onPongTimeout event ({1} consecutive)"
 msgstr ""
 
 #. debug
-#: lib/src/connector/connection.cc:518
+#: lib/src/connector/connection.cc:522
 msgid "WebSocket on open event - {1}"
 msgstr ""
 
 #. info
-#: lib/src/connector/connection.cc:519
+#: lib/src/connector/connection.cc:523
 msgid ""
 "Successfully established a WebSocket connection with the PCP broker at {1}"
 msgstr ""
 
 #. error
-#: lib/src/connector/connection.cc:528
+#: lib/src/connector/connection.cc:532
 msgid "onOpen callback failure: {1}; closing the WebSocket connection"
 msgstr ""
 
 #. error
-#: lib/src/connector/connection.cc:531
+#: lib/src/connector/connection.cc:535
 msgid "onOpen callback failure; closing the WebSocket connection"
 msgstr ""
 
 #. error
-#: lib/src/connector/connection.cc:547
+#: lib/src/connector/connection.cc:551
 msgid "onMessage WebSocket callback failure: {1}"
 msgstr ""
 
 #. error
-#: lib/src/connector/connection.cc:549
+#: lib/src/connector/connection.cc:553
 msgid "onMessage WebSocket callback failure: unexpected error"
 msgstr ""
 
 #. info
-#: lib/src/connector/connector.cc:119
+#: lib/src/connector/connector.cc:126
 msgid "Resetting the WebSocket event callbacks"
 msgstr ""
 
 #. debug
-#: lib/src/connector/connector.cc:182
+#: lib/src/connector/connector.cc:194
 msgid ""
 "There's an ongoing attempt to create a WebSocket connection; ensuring that "
 "it's closed before Associate Session"
 msgstr ""
 
 #. warning
-#: lib/src/connector/connector.cc:198
+#: lib/src/connector/connector.cc:210
 msgid "Unexpected - failed to close the WebSocket connection"
 msgstr ""
 
 #. warning
-#: lib/src/connector/connector.cc:204
+#: lib/src/connector/connector.cc:216
 msgid ""
 "WebSocket close failure ({1}); will continue with the Associate Session "
 "attempt"
 msgstr ""
 
 #. info
-#: lib/src/connector/connector.cc:231
+#: lib/src/connector/connector.cc:244
 msgid "Waiting for the PCP Session Association to complete"
 msgstr ""
 
 #. debug
-#: lib/src/connector/connector.cc:242
+#: lib/src/connector/connector.cc:254
 msgid "It seems that an error occurred during the Session Association ({1})"
 msgstr ""
 
-#: lib/src/connector/connector.cc:245
+#: lib/src/connector/connector.cc:257
 msgid "undetermined error"
 msgstr ""
 
-#: lib/src/connector/connector.cc:249
+#: lib/src/connector/connector.cc:261
 msgid "invalid Associate Session response"
 msgstr ""
 
 #. debug
-#: lib/src/connector/connector.cc:252
+#: lib/src/connector/connector.cc:264
 msgid "Associate Session timed out"
 msgstr ""
 
-#: lib/src/connector/connector.cc:255
+#: lib/src/connector/connector.cc:267
 msgid "operation timeout"
 msgstr ""
 
-#: lib/src/connector/connector.cc:258
+#: lib/src/connector/connector.cc:270
 msgid "Associate Session failure"
 msgstr ""
 
 #. debug
-#: lib/src/connector/connector.cc:271
+#: lib/src/connector/connector.cc:283
 msgid "Failed to establish the WebSocket connection: {1}"
 msgstr ""
 
 #. warning
-#: lib/src/connector/connector.cc:294
+#: lib/src/connector/connector.cc:311
 msgid "The Monitoring Thread is already running"
 msgstr ""
 
 #. warning
-#: lib/src/connector/connector.cc:302
+#: lib/src/connector/connector.cc:320
 msgid "The Monitoring Thread is not running"
 msgstr ""
 
 #. debug
-#: lib/src/connector/connector.cc:313
+#: lib/src/connector/connector.cc:332
 msgid ""
 "Sending message of {1} bytes:\n"
 "{2}"
 msgstr ""
 
-#: lib/src/connector/connector.cc:381
+#: lib/src/connector/connector.cc:405
 msgid "connection not initialized"
 msgstr ""
 
 #. debug
-#: lib/src/connector/connector.cc:394
+#: lib/src/connector/connector.cc:419
 msgid "Creating message with id {1} for {2} receiver"
 msgstr ""
 
 #. debug
-#: lib/src/connector/connector.cc:397
+#: lib/src/connector/connector.cc:422
 msgid "Creating message with id {1} for {2} receivers"
 msgstr ""
 
 #. debug
-#: lib/src/connector/connector.cc:446
+#: lib/src/connector/connector.cc:473
 msgid ""
 "About to send Associate Session request; unexpectedly the Connector does not "
 "seem to be in the associating state"
 msgstr ""
 
 #. info
-#: lib/src/connector/connector.cc:464
+#: lib/src/connector/connector.cc:491
 msgid "Sending Associate Session request with id {1} and a TTL of {2} s"
 msgstr ""
 
 #. debug
-#: lib/src/connector/connector.cc:473
+#: lib/src/connector/connector.cc:501
 msgid ""
 "Received message of {1} bytes - raw message:\n"
 "{2}"
 msgstr ""
 
-#: lib/src/connector/connector.cc:484
+#: lib/src/connector/connector.cc:512
 msgid "Failed to deserialize message: {1}"
 msgstr ""
 
-#: lib/src/connector/connector.cc:494
+#: lib/src/connector/connector.cc:522
 msgid "Invalid envelope - bad content: {1}"
 msgstr ""
 
-#: lib/src/connector/connector.cc:496
+#: lib/src/connector/connector.cc:524
 msgid "Invalid envelope - invalid JSON content: {1}"
 msgstr ""
 
-#: lib/src/connector/connector.cc:500
+#: lib/src/connector/connector.cc:528
 msgid "Unknown schema: {1}"
 msgstr ""
 
 #. warning
-#: lib/src/connector/connector.cc:526
+#: lib/src/connector/connector.cc:554
 msgid "No message callback has be registered for the '{1}' schema"
 msgstr ""
 
 #. warning
-#: lib/src/connector/connector.cc:545
+#: lib/src/connector/connector.cc:574
 msgid "Received an unexpected Associate Session response; discarding it"
 msgstr ""
 
 #. warning
-#: lib/src/connector/connector.cc:551
+#: lib/src/connector/connector.cc:580
 msgid ""
 "Received an Associate Session response that refers to an unknown request ID "
 "({1}, expected {2}); discarding it"
 msgstr ""
 
-#: lib/src/connector/connector.cc:557
+#: lib/src/connector/connector.cc:586
 msgid "Received an Associate Session response {1} from {2} for the request {3}"
 msgstr ""
 
 #. info
-#: lib/src/connector/connector.cc:562
+#: lib/src/connector/connector.cc:591
 msgid "{1}: success"
 msgstr ""
 
 #. warning
-#: lib/src/connector/connector.cc:566
+#: lib/src/connector/connector.cc:595
 msgid "{1}: failure - {2}"
 msgstr ""
 
 #. warning
-#: lib/src/connector/connector.cc:569
+#: lib/src/connector/connector.cc:598
 msgid "{1}: failure"
 msgstr ""
 
-#: lib/src/connector/connector.cc:593
+#: lib/src/connector/connector.cc:623
 msgid "Received error {1} from {2}"
 msgstr ""
 
 #. warning
-#: lib/src/connector/connector.cc:598
+#: lib/src/connector/connector.cc:628
 msgid "{1} caused by message {2}: {3}"
 msgstr ""
 
 #. warning
-#: lib/src/connector/connector.cc:600
+#: lib/src/connector/connector.cc:630
 msgid "{1} (the id of the message that caused it is unknown): {2}"
 msgstr ""
 
 #. debug
-#: lib/src/connector/connector.cc:611
+#: lib/src/connector/connector.cc:641
 msgid "The error message {1} is due to the Associate Session request {2}"
 msgstr ""
 
 #. warning
-#: lib/src/connector/connector.cc:631
+#: lib/src/connector/connector.cc:662
 msgid "Received TTL Expired message {1} from {2} related to message {3}"
 msgstr ""
 
 #. debug
-#: lib/src/connector/connector.cc:643
+#: lib/src/connector/connector.cc:674
 msgid ""
 "The TTL expired message {1} is related to the Associate Session request {2}"
 msgstr ""
 
 #. info
-#: lib/src/connector/connector.cc:658
+#: lib/src/connector/connector.cc:691
 msgid "Starting the monitor task"
 msgstr ""
 
 #. warning
-#: lib/src/connector/connector.cc:674
+#: lib/src/connector/connector.cc:707
 msgid "WebSocket connection to PCP broker lost; retrying"
 msgstr ""
 
 #. debug
-#: lib/src/connector/connector.cc:677
+#: lib/src/connector/connector.cc:710
 msgid "Sending heartbeat ping"
 msgstr ""
 
 #. warning
-#: lib/src/connector/connector.cc:683
+#: lib/src/connector/connector.cc:716
 msgid ""
 "The connection monitor task will continue after a WebSocket failure ({1})"
 msgstr ""
 
 #. warning
-#: lib/src/connector/connector.cc:687
+#: lib/src/connector/connector.cc:720
 msgid ""
 "The connection monitor task will continue after an error during the Session "
 "Association ({1})"
 msgstr ""
 
 #. warning
-#: lib/src/connector/connector.cc:691
+#: lib/src/connector/connector.cc:724
 msgid ""
 "The connection monitor task will stop after an Session Association failure: "
 "{1}"
 msgstr ""
 
 #. warning
-#: lib/src/connector/connector.cc:697
+#: lib/src/connector/connector.cc:730
 msgid "The connection monitor task will stop: {1}"
 msgstr ""
 
 #. info
-#: lib/src/connector/connector.cc:703
+#: lib/src/connector/connector.cc:736
 msgid "Stopping the monitor task"
 msgstr ""
 
 #. info
-#: lib/src/connector/connector.cc:708
+#: lib/src/connector/connector.cc:741
 msgid "Stopping the Monitoring Thread"
 msgstr ""
 
 #. warning
-#: lib/src/connector/connector.cc:715
+#: lib/src/connector/connector.cc:748
 msgid "The Monitoring Thread is not joinable"
 msgstr ""
 


### PR DESCRIPTION
Adding new functionalities for the MockServer:
 - configurable handler for WebSocket pings;
 - Association Request handler (triggered by onMessage event).

The connection_check interval of Connector::startMonitoring is now an
argument of the method; this allows us to write unit tests with a
monitor task that has a very short period.

Adding new connector_test.cc with unit tests for Connector::connect and
Connector::startMonitoring (to ensure it reconnects when the broker goes
down and that the connection gets closed after a number of pong timeouts).