### PR TITLE
(PCP-463) Unit tests and improvements for Monitor errors

### DIFF
--- a/lib/inc/cpp-pcp-client/connector/client_metadata.hpp
+++ b/lib/inc/cpp-pcp-client/connector/client_metadata.hpp
@@ -38,7 +38,7 @@ class LIBCPP_PCP_CLIENT_EXPORT ClientMetadata {
                    uint32_t _association_timeout_s,
                    uint32_t _association_request_ttl_s,
                    uint32_t _pong_timeouts_before_retry,
-                   long _pong_timeout_ms = 30);
+                   long _pong_timeout_ms);
 };
 
 }  // namespace PCPClient

--- a/lib/tests/unit/connector/client_metadata_test.cc
+++ b/lib/tests/unit/connector/client_metadata_test.cc
@@ -31,13 +31,15 @@ static constexpr int WS_TIMEOUT { 5000 };
 static constexpr uint32_t ASSOCIATION_TIMEOUT_S { 15 };
 static constexpr uint32_t ASSOCIATION_REQUEST_TTL_S { 10 };
 static constexpr uint32_t PONG_TIMEOUTS_BEFORE_RETRY { 3 };
+static constexpr uint32_t PONG_TIMEOUT_MS { 10000 };
 
 TEST_CASE("ClientMetadata::ClientMetadata", "[connector]") {
     SECTION("retrieves correctly the client common name from the certificate") {
         std::string type { "test" };
         ClientMetadata c_m { type, getCaPath(), getCertPath(), getKeyPath(),
-                             WS_TIMEOUT, ASSOCIATION_TIMEOUT_S,
-                             ASSOCIATION_REQUEST_TTL_S, PONG_TIMEOUTS_BEFORE_RETRY };
+                             WS_TIMEOUT,
+                             ASSOCIATION_TIMEOUT_S, ASSOCIATION_REQUEST_TTL_S,
+                             PONG_TIMEOUTS_BEFORE_RETRY, PONG_TIMEOUT_MS };
 
         REQUIRE(c_m.common_name == "localhost");
     }
@@ -45,8 +47,9 @@ TEST_CASE("ClientMetadata::ClientMetadata", "[connector]") {
     SECTION("determines correctly the client URI") {
         std::string type { "test" };
         ClientMetadata c_m { type, getCaPath(), getCertPath(), getKeyPath(),
-                             WS_TIMEOUT, ASSOCIATION_TIMEOUT_S,
-                             ASSOCIATION_REQUEST_TTL_S, PONG_TIMEOUTS_BEFORE_RETRY };
+                             WS_TIMEOUT,
+                             ASSOCIATION_TIMEOUT_S, ASSOCIATION_REQUEST_TTL_S,
+                             PONG_TIMEOUTS_BEFORE_RETRY, PONG_TIMEOUT_MS };
         std::string expected_uri { "pcp://localhost/" + type };
 
         REQUIRE(c_m.uri == expected_uri);
@@ -58,7 +61,7 @@ TEST_CASE("ClientMetadata::ClientMetadata", "[connector]") {
                                          getNotExistentFilePath(), getKeyPath(),
                                          WS_TIMEOUT, ASSOCIATION_TIMEOUT_S,
                                          ASSOCIATION_REQUEST_TTL_S,
-                                         PONG_TIMEOUTS_BEFORE_RETRY),
+                                         PONG_TIMEOUTS_BEFORE_RETRY, PONG_TIMEOUT_MS),
                           connection_config_error);
     }
 
@@ -68,7 +71,7 @@ TEST_CASE("ClientMetadata::ClientMetadata", "[connector]") {
                                          getKeyPath(),
                                          WS_TIMEOUT, ASSOCIATION_TIMEOUT_S,
                                          ASSOCIATION_REQUEST_TTL_S,
-                                         PONG_TIMEOUTS_BEFORE_RETRY),
+                                         PONG_TIMEOUTS_BEFORE_RETRY, PONG_TIMEOUT_MS),
                           connection_config_error);
     }
 }

--- a/lib/tests/unit/connector/connection_test.cc
+++ b/lib/tests/unit/connector/connection_test.cc
@@ -17,13 +17,15 @@ static constexpr int WS_TIMEOUT { 5000 };
 static constexpr uint32_t ASSOCIATION_TIMEOUT_S { 15 };
 static constexpr uint32_t ASSOCIATION_REQUEST_TTL_S { 10 };
 static constexpr uint32_t PONG_TIMEOUTS_BEFORE_RETRY { 3 };
+static constexpr uint32_t PONG_TIMEOUT_MS { 30000 };
 
 TEST_CASE("Connection::connect errors", "[connection]") {
     SECTION("throws a connection_processing_error if the broker url is "
             "not a valid WebSocket url") {
         ClientMetadata c_m { "test_client", getCaPath(), getCertPath(),
-                             getKeyPath(), 6, ASSOCIATION_TIMEOUT_S,
-                             ASSOCIATION_REQUEST_TTL_S, PONG_TIMEOUTS_BEFORE_RETRY };
+                             getKeyPath(), 6,
+                             ASSOCIATION_TIMEOUT_S, ASSOCIATION_REQUEST_TTL_S,
+                             PONG_TIMEOUTS_BEFORE_RETRY, PONG_TIMEOUT_MS };
         // NB: the dtor will wait for the 6 ms specified above
         Connection connection { "foo", c_m };
 
@@ -44,8 +46,9 @@ static void let_connection_stop(Connection const& connection, int timeout = 2)
 TEST_CASE("Connection::connect", "[connection]") {
     SECTION("successfully connects") {
         ClientMetadata c_m { "test_client", getCaPath(), getCertPath(),
-                             getKeyPath(), WS_TIMEOUT, ASSOCIATION_TIMEOUT_S,
-                             ASSOCIATION_REQUEST_TTL_S, PONG_TIMEOUTS_BEFORE_RETRY };
+                             getKeyPath(), WS_TIMEOUT,
+                             ASSOCIATION_TIMEOUT_S, ASSOCIATION_REQUEST_TTL_S,
+                             PONG_TIMEOUTS_BEFORE_RETRY, PONG_TIMEOUT_MS };
 
         MockServer mock_server;
         bool connected = false;
@@ -65,8 +68,9 @@ TEST_CASE("Connection::connect", "[connection]") {
 
     SECTION("successfully connects to failover broker") {
         ClientMetadata c_m { "test_client", getCaPath(), getCertPath(),
-                             getKeyPath(), WS_TIMEOUT, ASSOCIATION_TIMEOUT_S,
-                             ASSOCIATION_REQUEST_TTL_S, PONG_TIMEOUTS_BEFORE_RETRY };
+                             getKeyPath(), WS_TIMEOUT,
+                             ASSOCIATION_TIMEOUT_S, ASSOCIATION_REQUEST_TTL_S,
+                             PONG_TIMEOUTS_BEFORE_RETRY, PONG_TIMEOUT_MS };
 
         MockServer mock_server;
         bool connected = false;
@@ -89,8 +93,9 @@ TEST_CASE("Connection::connect", "[connection]") {
 
     SECTION("successfully connects to failover when primary broker disappears") {
         ClientMetadata c_m { "test_client", getCaPath(), getCertPath(),
-                             getKeyPath(), WS_TIMEOUT, ASSOCIATION_TIMEOUT_S,
-                             ASSOCIATION_REQUEST_TTL_S, PONG_TIMEOUTS_BEFORE_RETRY };
+                             getKeyPath(), WS_TIMEOUT,
+                             ASSOCIATION_TIMEOUT_S, ASSOCIATION_REQUEST_TTL_S,
+                             PONG_TIMEOUTS_BEFORE_RETRY, PONG_TIMEOUT_MS };
 
         bool connected_a = false, connected_b = false, connected_c = false;
 
@@ -142,8 +147,9 @@ TEST_CASE("Connection::~Connection", "[connection]") {
     mock_server.go();
 
     ClientMetadata c_m { "test_client", getCaPath(), getCertPath(),
-                         getKeyPath(), WS_TIMEOUT, ASSOCIATION_TIMEOUT_S,
-                         ASSOCIATION_REQUEST_TTL_S, PONG_TIMEOUTS_BEFORE_RETRY };
+                         getKeyPath(), WS_TIMEOUT,
+                         ASSOCIATION_TIMEOUT_S, ASSOCIATION_REQUEST_TTL_S,
+                         PONG_TIMEOUTS_BEFORE_RETRY, PONG_TIMEOUT_MS };
 
     SECTION("connecting with a single attempt") {
         SECTION("connection timeout = 1 ms") {

--- a/lib/tests/unit/connector/connector_test.cc
+++ b/lib/tests/unit/connector/connector_test.cc
@@ -71,102 +71,18 @@ TEST_CASE("Connector::connect", "[connector]") {
     }
 }
 
-TEST_CASE("Connector::startMonitoring", "[connector]") {
+TEST_CASE("Connector's monitor task", "[connector]") {
+    bool use_blocking_call;
+
     SECTION("reconnects after the broker stops") {
-        std::unique_ptr<Connector> c_ptr;
-        uint16_t port;
-
-        {
-            MockServer mock_server;
-            bool connected = false;
-            mock_server.set_open_handler(
-                    [&connected](websocketpp::connection_hdl hdl) {
-                        connected = true;
-                    });
-            mock_server.go();
-            port = mock_server.port();
-
-            c_ptr.reset(new Connector("wss://localhost:" + std::to_string(port) + "/pcp",
-                                      "test_client",
-                                      getCaPath(), getCertPath(), getKeyPath(),
-                                      WS_TIMEOUT_MS, ASSOCIATION_TIMEOUT_S,
-                                      ASSOCIATION_REQUEST_TTL_S,
-                                      PONG_TIMEOUTS_BEFORE_RETRY));
-
-            REQUIRE_FALSE(connected);
-            REQUIRE_NOTHROW(c_ptr->connect(1));
-            REQUIRE(c_ptr->isConnected());
-            REQUIRE(connected);
-
-            // Infinite retries; 1 s between each WebSocket ping
-            REQUIRE_NOTHROW(c_ptr->startMonitoring(0, 1));
+        SECTION("when using NON blocking calls (start/stopMonitoring") {
+            use_blocking_call = false;
         }
 
-        // The broker does not exist anymore (RAII)
-        wait_for([&c_ptr](){return !c_ptr->isConnected();});
+        SECTION("when using blocking calls (monitorConnection and dtor)") {
+            use_blocking_call = true;
+        }
 
-        REQUIRE_FALSE(c_ptr->isConnected());
-
-        MockServer mock_server {port};
-        mock_server.go();
-
-        wait_for([&c_ptr](){return c_ptr->isConnected();});
-
-        REQUIRE(c_ptr->isConnected());
-
-        wait_for([&c_ptr](){return c_ptr->isAssociated();});
-
-        REQUIRE(c_ptr->isAssociated());
-
-        REQUIRE_NOTHROW(c_ptr->stopMonitoring());
-    }
-
-    SECTION("reconnects after 1 pong timeout") {
-        MockServer mock_server;
-        std::atomic<int> num_connections {0};
-        std::atomic<int> num_pings {0};
-        mock_server.set_open_handler(
-                [&num_connections](websocketpp::connection_hdl hdl) {
-                    ++num_connections;
-                });
-        mock_server.set_ping_handler(
-                [&num_pings](websocketpp::connection_hdl hdl, std::string) -> bool {
-                    ++num_pings;
-                    return false;
-                });
-        mock_server.go();
-        auto port = mock_server.port();
-
-        // Setting the pong timeout to 500 ms and the Association
-        // timeout to 1 s (Connector::connect will hang waiting for
-        // for the Association completion that won't happen because
-        // we'll be done as soon as num_connections > 1)
-        Connector c { "wss://localhost:" + std::to_string(port) + "/pcp",
-                      "test_client",
-                      getCaPath(), getCertPath(), getKeyPath(),
-                      WS_TIMEOUT_MS, 1, ASSOCIATION_REQUEST_TTL_S, 1, 500 };
-
-        REQUIRE(num_connections == 0);
-        REQUIRE(num_pings == 0);
-        REQUIRE_NOTHROW(c.connect(1));
-        REQUIRE(c.isConnected());
-        REQUIRE(num_connections == 1);
-
-        // Infinite retries; 1 s between each WebSocket ping
-        REQUIRE_NOTHROW(c.startMonitoring(0, 1));
-
-        // After 1 pong timeout, the Connector should close and reconnect
-        wait_for([&num_connections](){return num_connections > 1;}, 30);
-
-        REQUIRE(num_connections > 1);
-        REQUIRE(num_pings > 0);
-
-        REQUIRE_NOTHROW(c.stopMonitoring());
-    }
-}
-
-TEST_CASE("Connector::monitorConnection", "[connector]") {
-    SECTION("reconnects after the broker stops") {
         std::unique_ptr<Connector> c_ptr;
         uint16_t port;
         Util::thread monitor;
@@ -193,10 +109,15 @@ TEST_CASE("Connector::monitorConnection", "[connector]") {
             REQUIRE(c_ptr->isConnected());
             REQUIRE(connected);
 
-            // Infinite retries; 1 s between each WebSocket ping
-            monitor = Util::thread { [&]() {
-                REQUIRE_NOTHROW(c_ptr->monitorConnection(0, 1));
-            } };
+            // Monitor with infinite retries and 1 s between each WebSocket ping
+            if (use_blocking_call) {
+                monitor = Util::thread(
+                    [&]() {
+                        REQUIRE_NOTHROW(c_ptr->monitorConnection(0, 1));
+                    });
+            } else {
+                REQUIRE_NOTHROW(c_ptr->startMonitoring(0, 1));
+            }
         }
 
         // The broker does not exist anymore (RAII)
@@ -216,14 +137,30 @@ TEST_CASE("Connector::monitorConnection", "[connector]") {
         REQUIRE(c_ptr->isAssociated());
 
         REQUIRE_NOTHROW(c_ptr->stopMonitoring());
-        // Ensure monitoring halts completely before we attempt to destroy the connection.
-        // Otherwise destruction will attempt to cleanup the object before startMonitorTask
-        // has exited.
-        monitor.join();
+
+        if (use_blocking_call) {
+            if (monitor.joinable()) {
+                // Ensure monitoring halts completely before we attempt to
+                // destroy the connection. Otherwise destruction will attempt to
+                // cleanup the object before startMonitorTask has exited.
+                monitor.join();
+            } else {
+                FAIL("the monitor thread is not joinable");
+            }
+        }
     }
 
     SECTION("reconnects after 1 pong timeout") {
+        SECTION("when using NON blocking calls (start/stopMonitoring") {
+            use_blocking_call = false;
+        }
+
+        SECTION("when using blocking calls (monitorConnection and dtor)") {
+            use_blocking_call = true;
+        }
+
         MockServer mock_server;
+        Util::thread monitor;
         std::atomic<int> num_connections {0};
         std::atomic<int> num_pings {0};
         mock_server.set_open_handler(
@@ -253,10 +190,15 @@ TEST_CASE("Connector::monitorConnection", "[connector]") {
         REQUIRE(c.isConnected());
         REQUIRE(num_connections == 1);
 
-        // Infinite retries; 1 s between each WebSocket ping
-        Util::thread monitor { [&]() {
-            REQUIRE_NOTHROW(c.monitorConnection(0, 1));
-        } };
+        // Monitor with infinite retries and 1 s between each WebSocket ping
+        if (use_blocking_call) {
+            monitor = Util::thread(
+                [&]() {
+                    REQUIRE_NOTHROW(c.monitorConnection(0, 1));
+                });
+        } else {
+            REQUIRE_NOTHROW(c.startMonitoring(0, 1));
+        }
 
         // After 1 pong timeout, the Connector should close and reconnect
         wait_for([&num_connections](){return num_connections > 1;}, 30);
@@ -265,10 +207,17 @@ TEST_CASE("Connector::monitorConnection", "[connector]") {
         REQUIRE(num_pings > 0);
 
         REQUIRE_NOTHROW(c.stopMonitoring());
-        // Ensure monitoring halts completely before we attempt to destroy the connection.
-        // Otherwise destruction will attempt to cleanup the object before startMonitorTask
-        // has exited.
-        monitor.join();
+
+        if (use_blocking_call) {
+            if (monitor.joinable()) {
+                // Ensure monitoring halts completely before we attempt to
+                // destroy the connection. Otherwise destruction will attempt to
+                // cleanup the object before startMonitorTask has exited.
+                monitor.join();
+            } else {
+                FAIL("the monitor thread is not joinable");
+            }
+        }
     }
 }
 

--- a/locales/cpp-pcp-client.pot
+++ b/locales/cpp-pcp-client.pot
@@ -233,246 +233,261 @@ msgstr ""
 msgid "Resetting the WebSocket event callbacks"
 msgstr ""
 
+#. error
+#: lib/src/connector/connector.cc:137
+msgid "Error previously caught by the Monitor Thread: {1}"
+msgstr ""
+
+#. error
+#: lib/src/connector/connector.cc:139
+msgid "An unexpected error has been previously caught by the Monitor Thread"
+msgstr ""
+
 #. debug
-#: lib/src/connector/connector.cc:194
+#: lib/src/connector/connector.cc:203
 msgid ""
 "There's an ongoing attempt to create a WebSocket connection; ensuring that "
 "it's closed before Associate Session"
 msgstr ""
 
 #. warning
-#: lib/src/connector/connector.cc:210
+#: lib/src/connector/connector.cc:219
 msgid "Unexpected - failed to close the WebSocket connection"
 msgstr ""
 
 #. warning
-#: lib/src/connector/connector.cc:216
+#: lib/src/connector/connector.cc:225
 msgid ""
 "WebSocket close failure ({1}); will continue with the Associate Session "
 "attempt"
 msgstr ""
 
 #. info
-#: lib/src/connector/connector.cc:244
+#: lib/src/connector/connector.cc:253
 msgid "Waiting for the PCP Session Association to complete"
 msgstr ""
 
 #. debug
-#: lib/src/connector/connector.cc:254
+#: lib/src/connector/connector.cc:263
 msgid "It seems that an error occurred during the Session Association ({1})"
 msgstr ""
 
-#: lib/src/connector/connector.cc:257
+#: lib/src/connector/connector.cc:266
 msgid "undetermined error"
 msgstr ""
 
-#: lib/src/connector/connector.cc:261
+#: lib/src/connector/connector.cc:270
 msgid "invalid Associate Session response"
 msgstr ""
 
 #. debug
-#: lib/src/connector/connector.cc:264
+#: lib/src/connector/connector.cc:273
 msgid "Associate Session timed out"
 msgstr ""
 
-#: lib/src/connector/connector.cc:267
+#: lib/src/connector/connector.cc:276
 msgid "operation timeout"
 msgstr ""
 
-#: lib/src/connector/connector.cc:270
+#: lib/src/connector/connector.cc:279
 msgid "Associate Session failure"
 msgstr ""
 
 #. debug
-#: lib/src/connector/connector.cc:283
+#: lib/src/connector/connector.cc:292
 msgid "Failed to establish the WebSocket connection: {1}"
 msgstr ""
 
 #. warning
-#: lib/src/connector/connector.cc:311
-#: lib/src/connector/connector.cc:342
+#: lib/src/connector/connector.cc:320
+#: lib/src/connector/connector.cc:355
 msgid "The Monitoring Thread is already running"
 msgstr ""
 
+#. debug
+#: lib/src/connector/connector.cc:331
+msgid "The Monitoring Thread previously caught an exception; re-throwing it"
+msgstr ""
+
 #. warning
-#: lib/src/connector/connector.cc:320
+#: lib/src/connector/connector.cc:335
 msgid "The Monitoring Thread is not running"
 msgstr ""
 
 #. debug
-#: lib/src/connector/connector.cc:352
+#: lib/src/connector/connector.cc:365
 msgid ""
 "Sending message of {1} bytes:\n"
 "{2}"
 msgstr ""
 
-#: lib/src/connector/connector.cc:425
+#: lib/src/connector/connector.cc:438
 msgid "connection not initialized"
 msgstr ""
 
 #. debug
-#: lib/src/connector/connector.cc:439
+#: lib/src/connector/connector.cc:452
 msgid "Creating message with id {1} for {2} receiver"
 msgstr ""
 
 #. debug
-#: lib/src/connector/connector.cc:442
+#: lib/src/connector/connector.cc:455
 msgid "Creating message with id {1} for {2} receivers"
 msgstr ""
 
 #. debug
-#: lib/src/connector/connector.cc:493
+#: lib/src/connector/connector.cc:506
 msgid ""
 "About to send Associate Session request; unexpectedly the Connector does not "
 "seem to be in the associating state"
 msgstr ""
 
 #. info
-#: lib/src/connector/connector.cc:511
+#: lib/src/connector/connector.cc:524
 msgid "Sending Associate Session request with id {1} and a TTL of {2} s"
 msgstr ""
 
 #. debug
-#: lib/src/connector/connector.cc:521
+#: lib/src/connector/connector.cc:534
 msgid ""
 "Received message of {1} bytes - raw message:\n"
 "{2}"
 msgstr ""
 
-#: lib/src/connector/connector.cc:532
+#: lib/src/connector/connector.cc:545
 msgid "Failed to deserialize message: {1}"
 msgstr ""
 
-#: lib/src/connector/connector.cc:542
+#: lib/src/connector/connector.cc:555
 msgid "Invalid envelope - bad content: {1}"
 msgstr ""
 
-#: lib/src/connector/connector.cc:544
+#: lib/src/connector/connector.cc:557
 msgid "Invalid envelope - invalid JSON content: {1}"
 msgstr ""
 
-#: lib/src/connector/connector.cc:548
+#: lib/src/connector/connector.cc:561
 msgid "Unknown schema: {1}"
 msgstr ""
 
 #. warning
-#: lib/src/connector/connector.cc:574
+#: lib/src/connector/connector.cc:587
 msgid "No message callback has be registered for the '{1}' schema"
 msgstr ""
 
 #. warning
-#: lib/src/connector/connector.cc:594
+#: lib/src/connector/connector.cc:607
 msgid "Received an unexpected Associate Session response; discarding it"
 msgstr ""
 
 #. warning
-#: lib/src/connector/connector.cc:600
+#: lib/src/connector/connector.cc:613
 msgid ""
 "Received an Associate Session response that refers to an unknown request ID "
 "({1}, expected {2}); discarding it"
 msgstr ""
 
-#: lib/src/connector/connector.cc:606
+#: lib/src/connector/connector.cc:619
 msgid "Received an Associate Session response {1} from {2} for the request {3}"
 msgstr ""
 
 #. info
-#: lib/src/connector/connector.cc:611
+#: lib/src/connector/connector.cc:624
 msgid "{1}: success"
 msgstr ""
 
 #. warning
-#: lib/src/connector/connector.cc:615
+#: lib/src/connector/connector.cc:628
 msgid "{1}: failure - {2}"
 msgstr ""
 
 #. warning
-#: lib/src/connector/connector.cc:618
+#: lib/src/connector/connector.cc:631
 msgid "{1}: failure"
 msgstr ""
 
-#: lib/src/connector/connector.cc:643
+#: lib/src/connector/connector.cc:656
 msgid "Received error {1} from {2}"
 msgstr ""
 
 #. warning
-#: lib/src/connector/connector.cc:648
+#: lib/src/connector/connector.cc:661
 msgid "{1} caused by message {2}: {3}"
 msgstr ""
 
 #. warning
-#: lib/src/connector/connector.cc:650
+#: lib/src/connector/connector.cc:663
 msgid "{1} (the id of the message that caused it is unknown): {2}"
 msgstr ""
 
 #. debug
-#: lib/src/connector/connector.cc:661
+#: lib/src/connector/connector.cc:674
 msgid "The error message {1} is due to the Associate Session request {2}"
 msgstr ""
 
 #. warning
-#: lib/src/connector/connector.cc:682
+#: lib/src/connector/connector.cc:695
 msgid "Received TTL Expired message {1} from {2} related to message {3}"
 msgstr ""
 
 #. debug
-#: lib/src/connector/connector.cc:694
+#: lib/src/connector/connector.cc:707
 msgid ""
 "The TTL expired message {1} is related to the Associate Session request {2}"
 msgstr ""
 
 #. info
-#: lib/src/connector/connector.cc:713
+#: lib/src/connector/connector.cc:726
 msgid "Starting the monitor task"
 msgstr ""
 
 #. warning
-#: lib/src/connector/connector.cc:729
+#: lib/src/connector/connector.cc:742
 msgid "WebSocket connection to PCP broker lost; retrying"
 msgstr ""
 
 #. debug
-#: lib/src/connector/connector.cc:732
+#: lib/src/connector/connector.cc:745
 msgid "Sending heartbeat ping"
 msgstr ""
 
 #. warning
-#: lib/src/connector/connector.cc:738
+#: lib/src/connector/connector.cc:751
 msgid ""
 "The connection monitor task will continue after a WebSocket failure ({1})"
 msgstr ""
 
 #. warning
-#: lib/src/connector/connector.cc:742
+#: lib/src/connector/connector.cc:755
 msgid ""
 "The connection monitor task will continue after an error during the Session "
 "Association ({1})"
 msgstr ""
 
 #. warning
-#: lib/src/connector/connector.cc:746
+#: lib/src/connector/connector.cc:759
 msgid ""
 "The connection monitor task will stop after an Session Association failure: "
 "{1}"
 msgstr ""
 
 #. warning
-#: lib/src/connector/connector.cc:752
+#: lib/src/connector/connector.cc:765
 msgid "The connection monitor task will stop: {1}"
 msgstr ""
 
 #. info
-#: lib/src/connector/connector.cc:763
+#: lib/src/connector/connector.cc:776
 msgid "Stopping the monitor task"
 msgstr ""
 
 #. info
-#: lib/src/connector/connector.cc:768
+#: lib/src/connector/connector.cc:781
 msgid "Stopping the Monitoring Thread"
 msgstr ""
 
 #. warning
-#: lib/src/connector/connector.cc:775
+#: lib/src/connector/connector.cc:788
 msgid "The Monitoring Thread is not joinable"
 msgstr ""
 


### PR DESCRIPTION
 - Removing default value for pong timeout from ClientMetadata ctor
 - Refactoring Connector's unit tests
 - New unit tests for storing/rethrowing Monitor Thread exceptions
 - Rethrowing Monitor Thread exceptions after its completion