### PR TITLE
(PCP-440) MockServer logging and WS Closing Handshake

### DIFF
--- a/lib/inc/cpp-pcp-client/connector/timings.hpp
+++ b/lib/inc/cpp-pcp-client/connector/timings.hpp
@@ -14,7 +14,8 @@ namespace PCPClient {
 //
 
 struct LIBCPP_PCP_CLIENT_EXPORT ConnectionTimings {
-    using Duration_us = boost::chrono::duration<int, boost::micro>;
+    using Duration_us  = boost::chrono::duration<int, boost::micro>;
+    using Duration_min = boost::chrono::minutes;
 
     boost::chrono::high_resolution_clock::time_point start;
     boost::chrono::high_resolution_clock::time_point tcp_pre_init;
@@ -23,27 +24,71 @@ struct LIBCPP_PCP_CLIENT_EXPORT ConnectionTimings {
     boost::chrono::high_resolution_clock::time_point closing_handshake;
     boost::chrono::high_resolution_clock::time_point close;
 
-    bool connection_started { false };
-    bool connection_failed { false };
+    bool isOpen() const;
+    bool isClosingStarted() const;
+    bool isFailed() const;
+    bool isClosed() const;
 
     /// Sets the `start` time_point member to the current instant,
-    /// the other time_points to epoch, and the flags to false
+    /// the other time_points to epoch, and all state flags to false
     void reset();
+
+    /// Sets the `open` time_point member to the current instant
+    /// and sets the related flag
+    void setOpen();
+
+    /// Sets the `closing_handshake` time_point member to the
+    /// current instant and flags `closing_started`
+    void setClosing();
+
+    /// Sets the `close` time_point member to the current instant,
+    /// flags `closed` and sets `connection_failed` to onFail_event
+    void setClosed(bool onFail_event = false);
 
     /// Time interval to establish the TCP connection [us]
     Duration_us getTCPInterval() const;
 
-    /// Time interval to perform the WebSocket handshake [us]
-    Duration_us getHandshakeInterval() const;
+    /// Time interval to perform the WebSocket Opening Handshake [us];
+    /// it will return:
+    ///  - a null duration, if the WebSocket is not open;
+    ///  - the (tcp_post_init - tcp_pre_init) duration, otherwise.
+    Duration_us getOpeningHandshakeInterval() const;
 
-    /// Time interval to establish the WebSocket connection [us]
+    /// Time interval to establish the overall WebSocket connection [us];
+    /// it will return:
+    ///  - a null duration, if the WebSocket is not open;
+    ///  - the (open - start) duration, otherwise.
     Duration_us getWebSocketInterval() const;
 
-    /// Time interval until close or fail event [us]
-    Duration_us getCloseInterval() const;
+    /// Time interval to perform the WebSocket Closing Handshake [us];
+    /// it will return:
+    ///  - a null duration, if:
+    ///        * the Websocket is not open;
+    ///        * the Closing Handshake was not started by this client;
+    ///        * the Closing Handshake did not complete.
+    ///  - the (close - closing_handshake) duration, otherwise.
+    Duration_us getClosingHandshakeInterval() const;
 
-    /// Returns a string with the timings
+    /// Duration of the WebSocket connection [minutes]; it will return:
+    ///  - a null duration, if the WebSocket connection was not established;
+    ///  - the (close - start) duration, if the connection was established
+    ///    and, then, closed;
+    ///  - the (now - start) duration, otherwise.
+    Duration_min getOverallConnectionInterval_min() const;
+
+    /// As getOverallConnectionInterval_min, but the duration is in us.
+    Duration_us getOverallConnectionInterval_us() const;
+
+    /// Returns a string with the WebSocket Opening Handshake timings
     std::string toString() const;
+
+  private:
+    bool _open            { false };
+    bool _closing_started { false };
+    bool _failed          { false };
+    bool _closed          { false };
+
+    std::string getOverallDurationTxt() const;
 };
 
 //
@@ -63,15 +108,15 @@ struct LIBCPP_PCP_CLIENT_EXPORT AssociationTimings {
     bool closed { false };
 
     /// Sets the `start` time_point member to the current instant,
-    /// the other time_points to epoch, and the flags to false
+    /// the other time_points to epoch, and all flags to false
     void reset();
 
-    /// Sets the Association timestamp member to the current instant
+    /// Sets the Association time_point member to the current instant
     /// if `closed` was not flagged, otherwise use the close one, then
     /// flags `completed` and sets `success` as specified
     void setCompleted(bool _success = true);
 
-    /// Sets the session closure timestamp member to the current instant
+    /// Sets the session closure time_point member to the current instant
     /// and flags `closed`
     void setClosed();
 

--- a/lib/src/connector/connection.cc
+++ b/lib/src/connector/connection.cc
@@ -495,9 +495,15 @@ void Connection::onClose(WS_Connection_Handle hdl)
     Util::lock_guard<Util::mutex> the_lock { state_mutex_ };
     timings.setClosed();
     auto con = endpoint_->get_con_from_hdl(hdl);
-    LOG_DEBUG("WebSocket on close event: {1} (code: {2}) - {3}",
-              con->get_ec().message(), con->get_remote_close_code(),
-              timings.toString());
+    auto close_code = con->get_remote_close_code();
+
+    if (close_code == 1000) {
+        // Normal closure; don't log error code
+        LOG_DEBUG("WebSocket on close event (nromal) - {1}", timings.toString());
+    } else {
+        LOG_DEBUG("WebSocket on close event: {1} (code: {2}) - {3}",
+                  con->get_ec().message(), close_code, timings.toString());
+    }
 
     if (timings.isClosingStarted())
         LOG_DEBUG("WebSocket on close event - Closing Handshake {1} us",

--- a/lib/tests/main.cc
+++ b/lib/tests/main.cc
@@ -6,17 +6,15 @@
 
 #include <vector>
 
-// To enable log messages:
-// #define ENABLE_LOGGING
-
-#ifdef ENABLE_LOGGING
+// NB: ENABLE_PCP_LOGGING could be defined in test.hpp
+#ifdef ENABLE_PCP_LOGGING
 #define LEATHERMAN_LOGGING_NAMESPACE "puppetlabs.cpp_pcp_client.test"
 #include <leatherman/logging/logging.hpp>
 #include <boost/nowide/iostream.hpp>
 #endif
 
 int main(int argc, char** argv) {
-#ifdef ENABLE_LOGGING
+#ifdef ENABLE_PCP_LOGGING
     leatherman::logging::setup_logging(boost::nowide::cout);
     leatherman::logging::set_level(leatherman::logging::log_level::debug);
 #endif

--- a/lib/tests/test.hpp
+++ b/lib/tests/test.hpp
@@ -1,8 +1,12 @@
-#ifndef CTUN_CLIENT_TEST_TEST_H_
-#define CTUN_CLIENT_TEST_TEST_H_
+#ifndef PCP_CLIENT_TEST_TEST_HPP_
+#define PCP_CLIENT_TEST_TEST_HPP_
+
+// To enable log messages:
+// #define ENABLE_PCP_LOGGING
+// #define ENABLE_MOCKSERVER_WEBSOCKETPP_LOGGING
 
 #include "root_path.hpp"
 
 #include <catch.hpp>
 
-#endif  // CTUN_CLIENT_TEST_TEST_H_
+#endif  // PCP_CLIENT_TEST_TEST_HPP_

--- a/lib/tests/unit/connector/mock_server.cc
+++ b/lib/tests/unit/connector/mock_server.cc
@@ -7,8 +7,9 @@
 #define _WEBSOCKETPP_CPP11_SYSTEM_ERROR_
 #define _WEBSOCKETPP_NO_CPP11_THREAD_
 
-#include "mock_server.hpp"
-#include "certs.hpp"
+#include "tests/test.hpp"
+#include "tests/unit/connector/certs.hpp"
+#include "tests/unit/connector/mock_server.hpp"
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-variable"
@@ -44,6 +45,12 @@ MockServer::MockServer(uint16_t port,
       keyPath_(std::move(keyPath)),
       server_(new websocketpp::server<websocketpp::config::asio_tls>())
 {
+    // NB: ENABLE_MOCKSERVER_WEBSOCKETPP_LOGGING could be defined in test.hpp
+#ifndef ENABLE_MOCKSERVER_WEBSOCKETPP_LOGGING
+    server_->clear_access_channels(websocketpp::log::alevel::all);
+    server_->clear_error_channels(websocketpp::log::elevel::all);
+#endif
+
     namespace asio = websocketpp::lib::asio;
     server_->init_asio();
 

--- a/locales/cpp-pcp-client.pot
+++ b/locales/cpp-pcp-client.pot
@@ -161,95 +161,100 @@ msgid "TLS error: {1}"
 msgstr ""
 
 #. debug
-#: lib/src/connector/connection.cc:498
+#: lib/src/connector/connection.cc:502
+msgid "WebSocket on close event (nromal) - {1}"
+msgstr ""
+
+#. debug
+#: lib/src/connector/connection.cc:504
 msgid "WebSocket on close event: {1} (code: {2}) - {3}"
 msgstr ""
 
 #. debug
-#: lib/src/connector/connection.cc:503
+#: lib/src/connector/connection.cc:509
 msgid "WebSocket on close event - Closing Handshake {1} us"
 msgstr ""
 
 #. error
-#: lib/src/connector/connection.cc:512
+#: lib/src/connector/connection.cc:518
 msgid "onClose WebSocket callback failure: {1}"
 msgstr ""
 
 #. error
-#: lib/src/connector/connection.cc:514
+#: lib/src/connector/connection.cc:520
 msgid "onClose WebSocket callback failure: unexpected error"
 msgstr ""
 
 #. debug
-#: lib/src/connector/connection.cc:524
+#: lib/src/connector/connection.cc:530
 msgid "WebSocket on fail event - {1}"
 msgstr ""
 
 #. warning
-#: lib/src/connector/connection.cc:525
+#: lib/src/connector/connection.cc:531
 msgid "WebSocket on fail event (connection loss): {1} (code: {2})"
 msgstr ""
 
 #. error
-#: lib/src/connector/connection.cc:533
+#: lib/src/connector/connection.cc:539
 msgid "onFail WebSocket callback failure: {1}"
 msgstr ""
 
 #. error
-#: lib/src/connector/connection.cc:535
+#: lib/src/connector/connection.cc:541
 msgid "onFail WebSocket callback failure: unexpected error"
 msgstr ""
 
 #. debug
-#: lib/src/connector/connection.cc:549
+#: lib/src/connector/connection.cc:555
 msgid "WebSocket onPong event"
 msgstr ""
 
 #. warning
-#: lib/src/connector/connection.cc:560
+#: lib/src/connector/connection.cc:566
 msgid ""
 "WebSocket onPongTimeout event ({1} consecutive); closing the WebSocket "
 "connection"
 msgstr ""
 
 #. warning
-#: lib/src/connector/connection.cc:564
+#: lib/src/connector/connection.cc:570
 msgid "WebSocket onPongTimeout event"
 msgstr ""
 
 #. warning
-#: lib/src/connector/connection.cc:566
+#: lib/src/connector/connection.cc:572
 msgid "WebSocket onPongTimeout event ({1} consecutive)"
 msgstr ""
 
 #. debug
-#: lib/src/connector/connection.cc:585
+#: lib/src/connector/connection.cc:591
 msgid "WebSocket on open event - {1}"
 msgstr ""
 
 #. info
-#: lib/src/connector/connection.cc:586
+#: lib/src/connector/connection.cc:592
 msgid ""
 "Successfully established a WebSocket connection with the PCP broker at {1}"
 msgstr ""
 
 #. error
-#: lib/src/connector/connection.cc:595
+#: lib/src/connector/connection.cc:601
 msgid "onOpen callback failure: {1}; closing the WebSocket connection"
 msgstr ""
 
 #. error
-#: lib/src/connector/connection.cc:598
+#: lib/src/connector/connection.cc:604
 msgid "onOpen callback failure; closing the WebSocket connection"
 msgstr ""
 
 #. error
-#: lib/src/connector/connection.cc:615
+#: lib/src/connector/connection.cc:621
 msgid "onMessage WebSocket callback failure: {1}"
 msgstr ""
 
 #. error
-#: lib/src/connector/connection.cc:617
+#: lib/src/connector/connection.cc:623
 msgid "onMessage WebSocket callback failure: unexpected error"
 msgstr ""
 

--- a/locales/cpp-pcp-client.pot
+++ b/locales/cpp-pcp-client.pot
@@ -105,146 +105,151 @@ msgstr ""
 msgid "About to close the WebSocket connection"
 msgstr ""
 
-#: lib/src/connector/connection.cc:301
+#: lib/src/connector/connection.cc:302
 msgid "failed to close WebSocket connection: {1}"
 msgstr ""
 
 #. warning
-#: lib/src/connector/connection.cc:326
+#: lib/src/connector/connection.cc:327
 msgid "Cleanup failure: {1}"
 msgstr ""
 
 #. warning
-#: lib/src/connector/connection.cc:354
+#: lib/src/connector/connection.cc:355
 msgid "WebSocket in 'connecting' state; will try to close"
 msgstr ""
 
 #. warning
-#: lib/src/connector/connection.cc:361
+#: lib/src/connector/connection.cc:362
 msgid ""
 "Failed to close the WebSocket; will wait at most {1} ms before trying again"
 msgstr ""
 
-#: lib/src/connector/connection.cc:387
-#: lib/src/connector/connection.cc:399
+#: lib/src/connector/connection.cc:388
+#: lib/src/connector/connection.cc:400
 msgid "failed to establish the WebSocket connection with {1}: {2}"
 msgstr ""
 
 #. info
-#: lib/src/connector/connection.cc:391
+#: lib/src/connector/connection.cc:392
 msgid ""
 "Establishing the WebSocket connection with '{1}' with a timeout of {2} ms"
 msgstr ""
 
 #. warning
-#: lib/src/connector/connection.cc:416
+#: lib/src/connector/connection.cc:417
 msgid "Failed to connect to {1}; switching to {2}"
 msgstr ""
 
 #. debug
-#: lib/src/connector/connection.cc:439
+#: lib/src/connector/connection.cc:440
 msgid "Verifying {1}, issued by {2}. Verified: {3}"
 msgstr ""
 
 #. debug
-#: lib/src/connector/connection.cc:458
+#: lib/src/connector/connection.cc:459
 msgid "WebSocket TLS initialization event; about to validate the certificate"
 msgstr ""
 
 #. debug
-#: lib/src/connector/connection.cc:482
+#: lib/src/connector/connection.cc:483
 msgid "Initialized SSL context to verify broker {1}"
 msgstr ""
 
-#: lib/src/connector/connection.cc:487
+#: lib/src/connector/connection.cc:488
 msgid "TLS error: {1}"
 msgstr ""
 
 #. debug
-#: lib/src/connector/connection.cc:497
+#: lib/src/connector/connection.cc:498
 msgid "WebSocket on close event: {1} (code: {2}) - {3}"
 msgstr ""
 
+#. debug
+#: lib/src/connector/connection.cc:503
+msgid "WebSocket on close event - Closing Handshake {1} us"
+msgstr ""
+
 #. error
-#: lib/src/connector/connection.cc:506
+#: lib/src/connector/connection.cc:512
 msgid "onClose WebSocket callback failure: {1}"
 msgstr ""
 
 #. error
-#: lib/src/connector/connection.cc:508
+#: lib/src/connector/connection.cc:514
 msgid "onClose WebSocket callback failure: unexpected error"
 msgstr ""
 
 #. debug
-#: lib/src/connector/connection.cc:519
+#: lib/src/connector/connection.cc:524
 msgid "WebSocket on fail event - {1}"
 msgstr ""
 
 #. warning
-#: lib/src/connector/connection.cc:520
+#: lib/src/connector/connection.cc:525
 msgid "WebSocket on fail event (connection loss): {1} (code: {2})"
 msgstr ""
 
 #. error
-#: lib/src/connector/connection.cc:528
+#: lib/src/connector/connection.cc:533
 msgid "onFail WebSocket callback failure: {1}"
 msgstr ""
 
 #. error
-#: lib/src/connector/connection.cc:530
+#: lib/src/connector/connection.cc:535
 msgid "onFail WebSocket callback failure: unexpected error"
 msgstr ""
 
 #. debug
-#: lib/src/connector/connection.cc:544
+#: lib/src/connector/connection.cc:549
 msgid "WebSocket onPong event"
 msgstr ""
 
 #. warning
-#: lib/src/connector/connection.cc:555
+#: lib/src/connector/connection.cc:560
 msgid ""
 "WebSocket onPongTimeout event ({1} consecutive); closing the WebSocket "
 "connection"
 msgstr ""
 
 #. warning
-#: lib/src/connector/connection.cc:559
+#: lib/src/connector/connection.cc:564
 msgid "WebSocket onPongTimeout event"
 msgstr ""
 
 #. warning
-#: lib/src/connector/connection.cc:561
+#: lib/src/connector/connection.cc:566
 msgid "WebSocket onPongTimeout event ({1} consecutive)"
 msgstr ""
 
 #. debug
-#: lib/src/connector/connection.cc:581
+#: lib/src/connector/connection.cc:585
 msgid "WebSocket on open event - {1}"
 msgstr ""
 
 #. info
-#: lib/src/connector/connection.cc:582
+#: lib/src/connector/connection.cc:586
 msgid ""
 "Successfully established a WebSocket connection with the PCP broker at {1}"
 msgstr ""
 
 #. error
-#: lib/src/connector/connection.cc:591
+#: lib/src/connector/connection.cc:595
 msgid "onOpen callback failure: {1}; closing the WebSocket connection"
 msgstr ""
 
 #. error
-#: lib/src/connector/connection.cc:594
+#: lib/src/connector/connection.cc:598
 msgid "onOpen callback failure; closing the WebSocket connection"
 msgstr ""
 
 #. error
-#: lib/src/connector/connection.cc:611
+#: lib/src/connector/connection.cc:615
 msgid "onMessage WebSocket callback failure: {1}"
 msgstr ""
 
 #. error
-#: lib/src/connector/connection.cc:613
+#: lib/src/connector/connection.cc:617
 msgid "onMessage WebSocket callback failure: unexpected error"
 msgstr ""
 
@@ -513,47 +518,51 @@ msgstr ""
 msgid "The Monitoring Thread is not joinable"
 msgstr ""
 
-#: lib/src/connector/timings.cc:54
-msgid "connection timings: TCP {1} us, WS handshake {2} us, overall {3} us"
-msgstr ""
-
-#: lib/src/connector/timings.cc:60
-msgid "time to failure {1} us"
-msgstr ""
-
-#: lib/src/connector/timings.cc:62
-msgid "the endpoint has not been connected yet"
-msgstr ""
-
-#: lib/src/connector/timings.cc:123
+#: lib/src/connector/timings.cc:19
 msgid "{1} hrs {2} min"
 msgstr ""
 
-#: lib/src/connector/timings.cc:125
+#: lib/src/connector/timings.cc:21
 msgid "{1} min"
 msgstr ""
 
-#: lib/src/connector/timings.cc:131
+#: lib/src/connector/timings.cc:132
+msgid "connection timings: TCP {1} us, WS handshake {2} us, overall {3} us"
+msgstr ""
+
+#: lib/src/connector/timings.cc:138
+msgid "time to failure {1}"
+msgstr ""
+
+#: lib/src/connector/timings.cc:140
+msgid "the endpoint has not been connected yet"
+msgstr ""
+
+#: lib/src/connector/timings.cc:151
+msgid "{1} us"
+msgstr ""
+
+#: lib/src/connector/timings.cc:209
 msgid "the endpoint has not been associated yet"
 msgstr ""
 
-#: lib/src/connector/timings.cc:136
+#: lib/src/connector/timings.cc:214
 msgid ""
 "PCP Session Association successfully completed in {1} ms, then closed after "
 "{2}"
 msgstr ""
 
-#: lib/src/connector/timings.cc:142
+#: lib/src/connector/timings.cc:220
 msgid ""
 "PCP Session Association successfully completed in {1} ms; the current "
 "session has been associated for {2}"
 msgstr ""
 
-#: lib/src/connector/timings.cc:148
+#: lib/src/connector/timings.cc:226
 msgid "PCP Session Association successfully completed in {1} ms"
 msgstr ""
 
-#: lib/src/connector/timings.cc:152
+#: lib/src/connector/timings.cc:230
 msgid "PCP Session Association failed after {1} ms"
 msgstr ""
 


### PR DESCRIPTION
Making the websocketpp logging for MockServer optional, 
as done for PCP logging within unit tests.
Macros are now listed in tests/test.hpp.

Retrieving WS Closing Handshake timings if the close() synch method was
triggered by the client endpoint. Adding logic for doing that in
ConnectionTimings.

Making state flags of ConnectionTimings private and adding getters.

Adding new unit tests for the ConnectionTimings changes.

Don't log error when onClose's code is 1000 (normal).