### PR TITLE
(PCP-477) Check connection by synchronizing onOpen events

### DIFF
--- a/.travis_target.sh
+++ b/.travis_target.sh
@@ -4,6 +4,13 @@ set -ev
 # Set compiler to GCC 4.8 here, as Travis overrides the global variables.
 export CC=gcc-4.8 CXX=g++-4.8
 
+get_gettext() {
+  wget https://s3.amazonaws.com/kylo-pl-bucket/gettext-0.19.6_install.tar.bz2
+  tar xjvf gettext-0.19.6_install.tar.bz2 --strip 1 -C $USERDIR
+  rm -f ../locales/cpp-pcp-client.pot
+  export MAKE_TARGET="all"
+}
+
 if [ ${TRAVIS_TARGET} == CPPCHECK ]; then
   # grab a pre-built cppcheck from s3
   wget https://s3.amazonaws.com/kylo-pl-bucket/pcre-8.36_install.tar.bz2
@@ -13,6 +20,9 @@ if [ ${TRAVIS_TARGET} == CPPCHECK ]; then
 elif [ ${TRAVIS_TARGET} == DEBUG ]; then
   # Install coveralls.io update utility
   pip install --user cpp-coveralls
+  get_gettext
+else
+  get_gettext
 fi
 
 # Generate build files

--- a/lib/inc/cpp-pcp-client/connector/connection.hpp
+++ b/lib/inc/cpp-pcp-client/connector/connection.hpp
@@ -178,6 +178,10 @@ class LIBCPP_PCP_CLIENT_EXPORT Connection {
     /// Transport layer event loop thread
     std::shared_ptr<Util::thread> endpoint_thread_;
 
+    /// To synchronize the onOpen event
+    Util::condition_variable onOpen_cv;
+    Util::mutex onOpen_mtx;
+
     // Callback functions called by the WebSocket event handlers.
     std::function<void()> onOpen_callback_;
     std::function<void(const std::string& message)> onMessage_callback_;

--- a/lib/tests/unit/connector/connection_test.cc
+++ b/lib/tests/unit/connector/connection_test.cc
@@ -78,6 +78,12 @@ static void let_connection_stop(Connection const& connection, int timeout = 2)
     REQUIRE(connection.getConnectionState() != ConnectionState::open);
 }
 
+static void wait_for_server_open()
+{
+    static Util::chrono::milliseconds pause {20};
+    Util::this_thread::sleep_for(pause);
+}
+
 TEST_CASE("Connection::connect", "[connection]") {
     SECTION("successfully connects, closes, and sets Closing Handshake timings") {
         ClientMetadata c_m { "test_client", getCaPath(), getCertPath(),
@@ -95,6 +101,7 @@ TEST_CASE("Connection::connect", "[connection]") {
         Connection connection {
             "wss://localhost:" + std::to_string(mock_server.port()) + "/pcp", c_m };
         connection.connect(10);
+        wait_for_server_open();
         REQUIRE(connected);
 
         connection.close();
@@ -132,6 +139,7 @@ TEST_CASE("Connection::connect", "[connection]") {
                                        "wss://localhost:" + std::to_string(port) + "/pcp" },
             c_m };
         connection.connect(30);
+        wait_for_server_open();
         REQUIRE(connected);
 
         connection.close();
@@ -165,12 +173,14 @@ TEST_CASE("Connection::connect", "[connection]") {
 
         mock_server_a->go();
         connection.connect(10);
+        wait_for_server_open();
         REQUIRE(connected_a);
         mock_server_a.reset();
         let_connection_stop(connection);
 
         mock_server_b->go();
         connection.connect(30);
+        wait_for_server_open();
         REQUIRE(connected_b);
         mock_server_b.reset();
         let_connection_stop(connection);
@@ -181,58 +191,70 @@ TEST_CASE("Connection::connect", "[connection]") {
         });
         mock_server_a->go();
         connection.connect(30);
+
+        wait_for_server_open();
         REQUIRE(connected_c);
     }
 }
 
 TEST_CASE("Connection::~Connection", "[connection]") {
-    MockServer mock_server;
-    bool connected = false;
-    mock_server.set_open_handler([&connected](websocketpp::connection_hdl hdl) {
-        connected = true;
-    });
-    mock_server.go();
+    SECTION("connect fails with connection timeout < server's processing time") {
+        MockServer mock_server;
+        ClientMetadata c_m { "test_client", getCaPath(), getCertPath(),
+                             getKeyPath(), WS_TIMEOUT,
+                             ASSOCIATION_TIMEOUT_S, ASSOCIATION_REQUEST_TTL_S,
+                             PONG_TIMEOUTS_BEFORE_RETRY, PONG_TIMEOUT_MS };
 
-    ClientMetadata c_m { "test_client", getCaPath(), getCertPath(),
-                         getKeyPath(), WS_TIMEOUT,
-                         ASSOCIATION_TIMEOUT_S, ASSOCIATION_REQUEST_TTL_S,
-                         PONG_TIMEOUTS_BEFORE_RETRY, PONG_TIMEOUT_MS };
+        // The WebSocket connection must not be established before 10 ms
+        mock_server.set_tcp_pre_init_handler(
+                [](websocketpp::connection_hdl hdl) {
+                    Util::this_thread::sleep_for(Util::chrono::milliseconds(10));
+                });
 
-    SECTION("connecting with a single attempt") {
-        SECTION("connection timeout = 1 ms") {
-            c_m.ws_connection_timeout_ms = 1;
-        }
+        mock_server.go();
+        c_m.ws_connection_timeout_ms = 1;
+        Connection connection {
+                "wss://localhost:" + std::to_string(mock_server.port()) + "/pcp",
+                c_m };
 
-        SECTION("connection timeout = 990 ms") {
-            c_m.ws_connection_timeout_ms = 990;
-        }
+        // The connection timeout should fire and an onFail event
+        // should be triggered, followed by a connection_fatal_error
+        REQUIRE_THROWS_AS(connection.connect(1),
+                          connection_fatal_error);
 
-        {
-            Connection connection {
-                    "wss://localhost:" + std::to_string(mock_server.port()) + "/pcp",
-                    c_m };
-
-            // In case the connection timeout fires, this will trigger a
-            // WebSocket onFail event
-            REQUIRE_NOTHROW(connection.connect(1));
-
-            lth_util::Timer timer {};
-            while (connection.getConnectionState() == ConnectionState::connecting
-                   && timer.elapsed_seconds() < 2)
-                Util::this_thread::sleep_for(Util::chrono::milliseconds(1));
-
-            auto c_s = connection.getConnectionState();
-            auto open_or_closed = c_s == ConnectionState::open
-                                  || c_s == ConnectionState::closed;
-            REQUIRE(open_or_closed);
-
-            // Triggering the dtor
-        }
-
-        // Connector's dtor should be able to effectively stop the
-        // event handler and join its thread
-        REQUIRE(true);
+        // Triggering the dtor
     }
+
+    SECTION("succeeds with connection timeout = 990 ms") {
+        MockServer mock_server;
+        ClientMetadata c_m { "test_client", getCaPath(), getCertPath(),
+                             getKeyPath(), WS_TIMEOUT,
+                             ASSOCIATION_TIMEOUT_S, ASSOCIATION_REQUEST_TTL_S,
+                             PONG_TIMEOUTS_BEFORE_RETRY, PONG_TIMEOUT_MS };
+        mock_server.go();
+        c_m.ws_connection_timeout_ms = 990;
+        Connection connection {
+                "wss://localhost:" + std::to_string(mock_server.port()) + "/pcp",
+                c_m };
+
+        REQUIRE_NOTHROW(connection.connect(1));
+
+        lth_util::Timer timer {};
+        while (connection.getConnectionState() == ConnectionState::connecting
+               && timer.elapsed_seconds() < 2)
+            Util::this_thread::sleep_for(Util::chrono::milliseconds(1));
+
+        auto c_s = connection.getConnectionState();
+        auto open_or_closed = c_s == ConnectionState::open
+                              || c_s == ConnectionState::closed;
+        REQUIRE(open_or_closed);
+
+        // Triggering the dtor
+    }
+
+    // Connector's dtor should be able to effectively stop the
+    // event handler and join its thread
+    REQUIRE(true);
 }
 
 }  // namespace PCPClient

--- a/lib/tests/unit/connector/mock_server.cc
+++ b/lib/tests/unit/connector/mock_server.cc
@@ -95,6 +95,11 @@ uint16_t MockServer::port()
     return ec ? 0 : ep.port();
 }
 
+void MockServer::set_tcp_pre_init_handler(std::function<void(websocketpp::connection_hdl)> func)
+{
+    server_->set_tcp_pre_init_handler(func);
+}
+
 void MockServer::set_open_handler(std::function<void(websocketpp::connection_hdl)> func)
 {
     server_->set_open_handler(func);

--- a/lib/tests/unit/connector/mock_server.hpp
+++ b/lib/tests/unit/connector/mock_server.hpp
@@ -41,6 +41,8 @@ public:
     void go();
     uint16_t port();
 
+    void set_tcp_pre_init_handler(std::function<void(websocketpp::connection_hdl)> func);
+
     void set_open_handler(std::function<void(websocketpp::connection_hdl)> func);
 
     void set_ping_handler(std::function<bool(websocketpp::connection_hdl,


### PR DESCRIPTION
Here we introduce concurrency logic to synchronize onOpen events
between the onOpen handler and the synchronous connectAndWait blocking
call. Such logic replaces the old check and wait loop based of 200 ms
period and allows returning as soon as the onOpen event is triggered and
prevents further delays when performing the Session association.

Updating unit tests. That requires exposing MockServer's tcp_pre_init
handler to allow introducing a delay for  establishing the WebSocket
connection. Also introducing a 20 ms pause before checking if the onOpen
handler in the MockServer instance was called, after the client's
connect() call returned.

Also updating the gettext version used by Travis.