### PR TITLE
(maint) Use validate handler to delay MockServer

### DIFF
--- a/lib/tests/unit/connector/connection_test.cc
+++ b/lib/tests/unit/connector/connection_test.cc
@@ -206,9 +206,10 @@ TEST_CASE("Connection::~Connection", "[connection]") {
                              PONG_TIMEOUTS_BEFORE_RETRY, PONG_TIMEOUT_MS };
 
         // The WebSocket connection must not be established before 10 ms
-        mock_server.set_tcp_pre_init_handler(
+        mock_server.set_validate_handler(
                 [](websocketpp::connection_hdl hdl) {
                     Util::this_thread::sleep_for(Util::chrono::milliseconds(10));
+                    return true;
                 });
 
         mock_server.go();

--- a/lib/tests/unit/connector/mock_server.cc
+++ b/lib/tests/unit/connector/mock_server.cc
@@ -100,6 +100,11 @@ void MockServer::set_tcp_pre_init_handler(std::function<void(websocketpp::connec
     server_->set_tcp_pre_init_handler(func);
 }
 
+void MockServer::set_validate_handler(std::function<bool(websocketpp::connection_hdl)> func)
+{
+    server_->set_validate_handler(func);
+}
+
 void MockServer::set_open_handler(std::function<void(websocketpp::connection_hdl)> func)
 {
     server_->set_open_handler(func);

--- a/lib/tests/unit/connector/mock_server.hpp
+++ b/lib/tests/unit/connector/mock_server.hpp
@@ -43,6 +43,10 @@ public:
 
     void set_tcp_pre_init_handler(std::function<void(websocketpp::connection_hdl)> func);
 
+    // NOTE(ale): pausing  more than 15 ms in the `validate` handler
+    // may end up invalidating the received message
+    void set_validate_handler(std::function<bool(websocketpp::connection_hdl)> func);
+
     void set_open_handler(std::function<void(websocketpp::connection_hdl)> func);
 
     void set_ping_handler(std::function<bool(websocketpp::connection_hdl,


### PR DESCRIPTION
Here we use the validate handler to introduce delays for establishing
the WebSocket connection when testing.