### PR TITLE
(PCP-499) Ensure pong timeout is shorter than connection check

### DIFF
--- a/lib/inc/cpp-pcp-client/connector/connector.hpp
+++ b/lib/inc/cpp-pcp-client/connector/connector.hpp
@@ -52,7 +52,7 @@ class LIBCPP_PCP_CLIENT_EXPORT Connector {
               uint32_t association_timeout_s = 15,
               uint32_t association_request_ttl_s = 10,
               uint32_t pong_timeouts_before_retry = 3,
-              long ws_pong_timeout_ms = 30000);
+              long ws_pong_timeout_ms = 5000);
 
     Connector(std::vector<std::string> broker_ws_uris,
               std::string client_type,
@@ -63,7 +63,7 @@ class LIBCPP_PCP_CLIENT_EXPORT Connector {
               uint32_t association_timeout_s = 15,
               uint32_t association_request_ttl_s = 10,
               uint32_t pong_timeouts_before_retry = 3,
-              long ws_pong_timeout_ms = 30000);
+              long ws_pong_timeout_ms = 5000);
 
     /// Calls stopMonitorTaskAndWait if the Monitoring Task thread is
     /// still active. In case an exception was previously stored by

--- a/locales/cpp-pcp-client.pot
+++ b/locales/cpp-pcp-client.pot
@@ -332,6 +332,11 @@ msgstr ""
 msgid "Failed to establish the WebSocket connection ({1})"
 msgstr ""
 
+#: lib/src/connector/connector.cc
+msgid ""
+"pong timeout ({1} ms) must be less than connection check interval ({2} ms)"
+msgstr ""
+
 #. warning
 #: lib/src/connector/connector.cc
 msgid "The Monitoring Thread is already running"


### PR DESCRIPTION
Resets default pong timeout to 5 seconds, and throws an exception when
connection check is shorter than pong timeout (which prevents timeout
from occurring).