### PR TITLE
(PCP-543) Add ca mismatch as possible failure cause

### DIFF
--- a/lib/src/connector/connection.cc
+++ b/lib/src/connector/connection.cc
@@ -443,7 +443,7 @@ class verbose_verification
         if (!verified) {
             // Issue a warning. Avoid throwing exceptions because this will be called
             // by OpenSSL, and that code likely doesn't handle cleanup on exceptions.
-            LOG_WARNING("TLS handshake failed, no subject name matching {1} found", uri_);
+            LOG_WARNING("TLS handshake failed, no subject name matching {1} found, or ca mismatch", uri_);
         }
         return verified;
     }

--- a/locales/cpp-pcp-client.pot
+++ b/locales/cpp-pcp-client.pot
@@ -146,7 +146,8 @@ msgstr ""
 
 #. warning
 #: lib/src/connector/connection.cc
-msgid "TLS handshake failed, no subject name matching {1} found"
+msgid ""
+"TLS handshake failed, no subject name matching {1} found, or ca mismatch"
 msgstr ""
 
 #. debug


### PR DESCRIPTION
Adds ca mismatch as a possible reason that SSL verification could fail.