### PR TITLE
(PCP-556) PCP access logging

### DIFF
--- a/lib/inc/cpp-pcp-client/connector/connection.hpp
+++ b/lib/inc/cpp-pcp-client/connector/connection.hpp
@@ -147,6 +147,9 @@ class LIBCPP_PCP_CLIENT_EXPORT Connection {
     void close(CloseCode code = CloseCodeValues::normal,
                const std::string& reason = DEFAULT_CLOSE_REASON);
 
+    /// Return the current broker WebSocket URI to target
+    std::string const& getWsUri();
+
   private:
     /// WebSocket URIs of PCP brokers; first entry is the default
     std::vector<std::string> broker_ws_uris_;
@@ -206,9 +209,6 @@ class LIBCPP_PCP_CLIENT_EXPORT Connection {
 
     // Connect the endpoint
     void connect_();
-
-    /// Return the current broker WebSocket URI to target
-    std::string const& getWsUri();
 
     /// Switch broker WebSocket URI targets
     void switchWsUri();

--- a/lib/inc/cpp-pcp-client/util/logging.hpp
+++ b/lib/inc/cpp-pcp-client/util/logging.hpp
@@ -22,14 +22,7 @@ namespace leatherman {
 namespace PCPClient {
 namespace Util {
 
-void doLogAccess(std::string const& message,
-                 int line_num);
-
-static inline void logAccess(std::string const& message,
-                             int line_num)
-{
-    doLogAccess(message, line_num);
-}
+void logAccess(std::string const& message, int line_num);
 
 LIBCPP_PCP_CLIENT_EXPORT
 void setupLogging(std::ostream &stream,

--- a/lib/inc/cpp-pcp-client/util/logging.hpp
+++ b/lib/inc/cpp-pcp-client/util/logging.hpp
@@ -17,12 +17,12 @@ namespace leatherman {
    within the cpp-pcp-client library for logging to work.
 */
 
-#define LOG_ACCESS(message) PCPClient::Util::logAccess(message, __LINE__);
+#define LOG_ACCESS(message) PCPClient::Util::logAccess(message);
 
 namespace PCPClient {
 namespace Util {
 
-void logAccess(std::string const& message, int line_num);
+void logAccess(std::string const& message);
 
 LIBCPP_PCP_CLIENT_EXPORT
 void setupLogging(std::ostream &stream,

--- a/lib/inc/cpp-pcp-client/util/logging.hpp
+++ b/lib/inc/cpp-pcp-client/util/logging.hpp
@@ -3,6 +3,7 @@
 #include <cpp-pcp-client/export.h>
 
 #include <ostream>
+#include <memory>
 
 // Forward declaration for leatherman::logging::log_level
 namespace leatherman {
@@ -16,18 +17,31 @@ namespace leatherman {
    within the cpp-pcp-client library for logging to work.
 */
 
+#define LOG_ACCESS(message) PCPClient::Util::logAccess(message, __LINE__);
+
 namespace PCPClient {
 namespace Util {
 
-LIBCPP_PCP_CLIENT_EXPORT
-void setupLogging(std::ostream &stream,
-                  bool force_colorization,
-                  std::string const& loglevel_label);
+void doLogAccess(std::string const& message,
+                 int line_num);
+
+static inline void logAccess(std::string const& message,
+                             int line_num)
+{
+    doLogAccess(message, line_num);
+}
 
 LIBCPP_PCP_CLIENT_EXPORT
 void setupLogging(std::ostream &stream,
                   bool force_colorization,
-                  leatherman::logging::log_level const& lvl);
+                  std::string const& loglevel_label,
+                  std::shared_ptr<std::ofstream> access_stream = nullptr);
+
+LIBCPP_PCP_CLIENT_EXPORT
+void setupLogging(std::ostream &log_stream,
+                  bool force_colorization,
+                  leatherman::logging::log_level const& lvl,
+                  std::shared_ptr<std::ofstream> access_stream = nullptr);
 
 }  // namespace Util
 }  // namespace PCPClient

--- a/lib/src/util/logging.cc
+++ b/lib/src/util/logging.cc
@@ -65,26 +65,15 @@ void access_writer::consume(boost::log::record_view const &rec)
 // PCP Access Logging - logger
 //
 
-void logAccess(std::string const& message, int line_num)
+void logAccess(std::string const& message)
 {
     if (access_logger_enabled) {
         boost::log::sources::severity_logger<lth_log::log_level> slg;
-        static attrs::constant <std::string> namespace_attr{
-                "puppetlabs.pcp_client.connector"};
+        static attrs::constant <std::string> namespace_attr {
+                "puppetlabs.pcp_client.connector" };
         slg.add_attribute("AccessOutcome",
                           attrs::constant<std::string>(message));
-        slg.add_attribute("Namespace", namespace_attr);
-        slg.add_attribute("LineNum", attrs::constant<int>(line_num));
-
-        // TODO(ale): make leatherman.logging's color_writer::consume ignore
-        // empty messages (and don't stream 'message' below) or check the log
-        // level; in alternative, allow configuring the color_writer sink
-        // filter to avoid logging AccessOutcome messages (something like
-        // `lth_sink->set_filter(!expr::has_attr(access_outcome));`) - note
-        // that the on_message callback and the record log level are checked
-        // by the logger, not by color_writer::consume. Otherwise, as it's now,
-        // the access message will be logged if the configured log level > info.
-        BOOST_LOG_SEV(slg, lth_log::log_level::info) << message;
+        BOOST_LOG_SEV(slg, lth_log::log_level::none);
     }
 }
 

--- a/locales/cpp-pcp-client.pot
+++ b/locales/cpp-pcp-client.pot
@@ -410,6 +410,14 @@ msgstr ""
 msgid "Unknown schema: {1}"
 msgstr ""
 
+#: lib/src/connector/connector.cc
+msgid "DESERIALIZATION_ERROR %1% unknown unknown unknown"
+msgstr ""
+
+#: lib/src/connector/connector.cc
+msgid "AUTHORIZATION_SUCCESS %1% %2% %3% %4%"
+msgstr ""
+
 #. warning
 #: lib/src/connector/connector.cc
 msgid "No message callback has be registered for the '{1}' schema"


### PR DESCRIPTION
The WS URI of the broker that pxp-agent is connected to is needed for
logging PCP access; here we make the relevant Connector's method public.

Adding an ad-hoc sink backend that format log messages in a simplified
way, compared to leatherman's logging.

Configuring a new boost log sink with a filter specific for PCP access
logging.

Adding PCP access logger and exposing a logging macro, similar to what
leatherman.logging does.

Logging PCP access from the onMessage callback.