### PR TITLE
(PCP-582) Use boost::exception_ptr

### DIFF
--- a/lib/inc/cpp-pcp-client/connector/connector.hpp
+++ b/lib/inc/cpp-pcp-client/connector/connector.hpp
@@ -21,7 +21,6 @@
 #include <string>
 #include <map>
 #include <cstdint>
-#include <exception>
 
 namespace PCPClient {
 
@@ -285,7 +284,7 @@ class LIBCPP_PCP_CLIENT_EXPORT Connector {
     Util::mutex monitor_mutex_;
     Util::condition_variable monitor_cond_var_;
     bool must_stop_monitoring_;
-    std::exception_ptr monitor_exception_;
+    Util::exception_ptr monitor_exception_;
 
     /// To manage the Associate Session process
     SessionAssociation session_association_;

--- a/lib/inc/cpp-pcp-client/util/thread.hpp
+++ b/lib/inc/cpp-pcp-client/util/thread.hpp
@@ -5,12 +5,17 @@
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
 #include <boost/thread/thread.hpp>
 #include <boost/thread/locks.hpp>
+#include <boost/exception_ptr.hpp>
+#include <boost/throw_exception.hpp>
 #pragma GCC diagnostic pop
 
 /* This header encapsulates our use of threads and locking structures.
    During PCP-53 we were forced to switch from using std::thread to boost::thread.
    This encapsulation means that we can swtich back by changing boost::thread, etc
    to std::thread, etc here and leave the rest of the code untouched.
+
+   PCP-582 modifies this further to include exception_ptr, which libstdc++ doesn't
+   support on all architectures.
 */
 
 namespace PCPClient {
@@ -28,6 +33,8 @@ template <class T>
 using unique_lock = boost::unique_lock<T>;
 
 namespace this_thread = boost::this_thread;
+
+using exception_ptr = boost::exception_ptr;
 
 }  // namespace Util
 }  // namespace PCPClient


### PR DESCRIPTION
On some ARM architectures, GCC doesn't support std::exception_ptr. Use
boost's instead (which requires some tweaking).