### PR TITLE
(maint) Use boost.nowide stream for access logging

### DIFF
--- a/lib/inc/cpp-pcp-client/util/logging.hpp
+++ b/lib/inc/cpp-pcp-client/util/logging.hpp
@@ -2,8 +2,8 @@
 
 #include <cpp-pcp-client/export.h>
 
-#include <ostream>
 #include <memory>
+#include <ostream>
 
 // Forward declaration for leatherman::logging::log_level
 namespace leatherman {
@@ -28,13 +28,13 @@ LIBCPP_PCP_CLIENT_EXPORT
 void setupLogging(std::ostream &stream,
                   bool force_colorization,
                   std::string const& loglevel_label,
-                  std::shared_ptr<std::ofstream> access_stream = nullptr);
+                  std::shared_ptr<std::ostream> access_stream = nullptr);
 
 LIBCPP_PCP_CLIENT_EXPORT
 void setupLogging(std::ostream &log_stream,
                   bool force_colorization,
                   leatherman::logging::log_level const& lvl,
-                  std::shared_ptr<std::ofstream> access_stream = nullptr);
+                  std::shared_ptr<std::ostream> access_stream = nullptr);
 
 }  // namespace Util
 }  // namespace PCPClient

--- a/lib/src/util/logging.cc
+++ b/lib/src/util/logging.cc
@@ -84,7 +84,7 @@ void logAccess(std::string const& message)
 static void setupLoggingImp(std::ostream& log_stream,
                             bool force_colorization,
                             lth_log::log_level const& lvl,
-                            std::shared_ptr<std::ofstream> access_stream)
+                            std::shared_ptr<std::ostream> access_stream)
 {
     // General Logging
     lth_log::setup_logging(log_stream);
@@ -97,11 +97,10 @@ static void setupLoggingImp(std::ostream& log_stream,
     if (access_stream) {
         access_logger_enabled = true;
         using sink_t = sinks::synchronous_sink<access_writer>;
-        auto sink = boost::make_shared<sink_t>(std::move(access_stream));
+        boost::shared_ptr<sink_t> sink(new sink_t(std::move(access_stream)));
         sink->set_filter(expr::has_attr(access_outcome));
         auto core = boost::log::core::get();
         core->add_sink(sink);
-
     } else {
         access_logger_enabled = false;
     }
@@ -110,7 +109,7 @@ static void setupLoggingImp(std::ostream& log_stream,
 void setupLogging(std::ostream &log_stream,
                   bool force_colorization,
                   std::string const& loglevel_label,
-                  std::shared_ptr<std::ofstream> access_stream)
+                  std::shared_ptr<std::ostream> access_stream)
 {
     const std::map<std::string, lth_log::log_level> label_to_log_level {
             { "none", lth_log::log_level::none },
@@ -129,7 +128,7 @@ void setupLogging(std::ostream &log_stream,
 void setupLogging(std::ostream &log_stream,
                   bool force_colorization,
                   lth_log::log_level const& lvl,
-                  std::shared_ptr<std::ofstream> access_stream)
+                  std::shared_ptr<std::ostream> access_stream)
 {
     setupLoggingImp(log_stream, force_colorization, lvl, std::move(access_stream));
 }


### PR DESCRIPTION
Using boost::nowide::ofstream for the access logging stream.