### PR TITLE
(PCP-617) Fix Boost.Log sink initialization with Boost 1.62

### DIFF
--- a/lib/src/util/logging.cc
+++ b/lib/src/util/logging.cc
@@ -97,7 +97,7 @@ static void setupLoggingImp(std::ostream& log_stream,
     if (access_stream) {
         access_logger_enabled = true;
         using sink_t = sinks::synchronous_sink<access_writer>;
-        boost::shared_ptr<sink_t> sink(new sink_t(std::move(access_stream)));
+        auto sink = boost::make_shared<sink_t>(boost::make_shared<access_writer>(std::move(access_stream)));
         sink->set_filter(expr::has_attr(access_outcome));
         auto core = boost::log::core::get();
         core->add_sink(sink);


### PR DESCRIPTION
In Boost 1.62, the way sink argument forwarding appears to have changed
in such a way that it failed to identify the implicit creation of a
access_writer. Switch to explicitly creating the access_writer sink.