### PR TITLE
(PCP-679) Append client_type to connection URIs

### DIFF
--- a/lib/src/connector/v2/connector.cc
+++ b/lib/src/connector/v2/connector.cc
@@ -65,6 +65,11 @@ Connector::Connector(std::vector<std::string> broker_ws_uris,
                           std::move(pong_timeouts_before_retry),
                           std::move(ws_pong_timeout_ms) }
 {
+    // Rely on ConnectorBase being an abstract class with no operations in the constructor.
+    for (auto& broker : broker_ws_uris_) {
+        broker += (broker.back() == '/' ? "" : "/") + client_metadata_.client_type;
+    }
+
     // Add PCP schemas to the Validator instance member
     validator_.registerSchema(Protocol::EnvelopeSchema());
 

--- a/lib/tests/unit/connector/mock_server.cc
+++ b/lib/tests/unit/connector/mock_server.cc
@@ -87,11 +87,17 @@ void MockServer::go()
     bt_.reset(new boost::thread(&websocketpp::server<websocketpp::config::asio_tls>::run, server_.get()));
 }
 
-uint16_t MockServer::port()
+uint16_t MockServer::port() const
 {
     websocketpp::lib::asio::error_code ec;
     auto ep = server_->get_local_endpoint(ec);
     return ec ? 0 : ep.port();
+}
+
+std::string MockServer::connection_path(websocketpp::connection_hdl hdl) const
+{
+    auto conn = server_->get_con_from_hdl(hdl);
+    return conn->get_resource();
 }
 
 void MockServer::set_tcp_pre_init_handler(std::function<void(websocketpp::connection_hdl)> func)

--- a/lib/tests/unit/connector/mock_server.hpp
+++ b/lib/tests/unit/connector/mock_server.hpp
@@ -41,7 +41,8 @@ public:
                Version v = Version::v1);
     ~MockServer();
     void go();
-    uint16_t port();
+    uint16_t port() const;
+    std::string connection_path(websocketpp::connection_hdl) const;
 
     void set_tcp_pre_init_handler(std::function<void(websocketpp::connection_hdl)> func);
 


### PR DESCRIPTION
The prior commits adding PCP version 2 didn't append the client_type to
connection URIs, expecting that users would do it themselves. Since
client_type is already an argument, use it to modify the connection URIs
to match broker expectations.