### PR TITLE
(PCP-719) Use TLS v1.2

### DIFF
--- a/lib/src/connector/connection.cc
+++ b/lib/src/connector/connection.cc
@@ -467,7 +467,7 @@ WS_Context_Ptr Connection::onTlsInit(WS_Connection_Handle hdl)
     // NB: for TLS certificates, refer to:
     // www.boost.org/doc/libs/1_56_0/doc/html/boost_asio/reference/ssl__context.html
     WS_Context_Ptr ctx {
-        new boost::asio::ssl::context(boost::asio::ssl::context::tlsv1) };
+        new boost::asio::ssl::context(boost::asio::ssl::context::tlsv12_client) };
     try {
         // no_sslv2 and no_sslv3 here are not strictly necessary, as the tlsv1 method above
         // ensures we will not try to initiate any connection below TLSv1. However, this avoids

--- a/lib/tests/unit/connector/mock_server.cc
+++ b/lib/tests/unit/connector/mock_server.cc
@@ -59,7 +59,7 @@ MockServer::MockServer(uint16_t port,
 
     server_->set_tls_init_handler(
         [&](websocketpp::connection_hdl hdl) {
-            auto ctx = websocketpp::lib::make_shared<asio::ssl::context>(asio::ssl::context::tlsv1);
+            auto ctx = websocketpp::lib::make_shared<asio::ssl::context>(asio::ssl::context::tlsv12_server);
             ctx->set_options(asio::ssl::context::default_workarounds |
                              asio::ssl::context::no_sslv2 |
                              asio::ssl::context::no_sslv3 |


### PR DESCRIPTION
Previously boost.asio was configured to use TLS v1.0. This actually
prevented working with clients that only support TLS v1.1 or later. Use
TLS v1.2 instead.

Note that this only attempts to make TLS v1.2 connections, and will not
attempt any other type.