### PR TITLE
(PCP-734) Detect closed connection immediately and attempt reconnect

### DIFF
--- a/lib/inc/cpp-pcp-client/connector/connector_base.hpp
+++ b/lib/inc/cpp-pcp-client/connector/connector_base.hpp
@@ -169,6 +169,9 @@ class LIBCPP_PCP_CLIENT_EXPORT ConnectorBase {
     // Implement to define how incoming messages are handled.
     virtual void processMessage(const std::string& msg_txt) = 0;
 
+    /// Used to notify the Monitoring Task when a connection is lost
+    void notifyClose();
+
   private:
     /// Flag; true if monitorConnection is executing
     bool is_monitoring_;

--- a/lib/src/connector/v1/connector.cc
+++ b/lib/src/connector/v1/connector.cc
@@ -143,6 +143,7 @@ void Connector::connect(int max_connect_attempts)
         connection_ptr_->setOnCloseCallback(
             [this]() {
                 closeAssociationTimings();
+                notifyClose();
             });
 
         connection_ptr_->setOnFailCallback(


### PR DESCRIPTION
Previously failed connections would only be detected on the
ping-interval. Notify of disconnects immediately, with a 200ms delay
before attempting to reconnect to avoid busy waiting against pcp-broker.