### PR TITLE
(PE-21053) Enable nxcompat and dynamicbase flags in Windows builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,10 @@ set(CPP_PCP_CLIENT_FLAGS "-Wno-deprecated-declarations -Wno-reorder -Wno-sign-co
 set(CMAKE_CXX_FLAGS "${LEATHERMAN_CXX_FLAGS} ${CPP_PCP_CLIENT_FLAGS}")
 add_definitions(${LEATHERMAN_DEFINITIONS})
 
+if (WIN32)
+link_libraries("-Wl,--nxcompat -Wl,--dynamicbase")
+endif()
+
 if(DEV_LOG_RAW_MESSAGE)
     add_definitions(-DDEV_LOG_RAW_MESSAGE)
 endif()


### PR DESCRIPTION
Being done to meet customer's security audit requirements.

Pl see notes in the ticket on why these changes need to be done in individual projects like this and all others dependent on leatherman and not leatherman itself. 