### PR TITLE
(PA-2055) Quiet boost 1.67 warnings on windows

### DIFF
--- a/lib/inc/cpp-pcp-client/util/thread.hpp
+++ b/lib/inc/cpp-pcp-client/util/thread.hpp
@@ -3,6 +3,7 @@
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#pragma GCC diagnostic ignored "-Wunused-variable"
 #include <boost/thread/thread.hpp>
 #include <boost/thread/locks.hpp>
 #include <boost/exception_ptr.hpp>


### PR DESCRIPTION
In preparing puppet-agent for boost 1.67 (https://github.com/puppetlabs/puppet-agent/pull/1482), we found that a 1.67 thread header defines an an unused variable on Windows under mingw; This ignores the warning so that it doesn't fail the build while using -Werror.