### PR TITLE
(maint) Fix Endian warning in Serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Dependencies
 
  - a C++11 compiler (clang/gcc 4.7)
  - CMake (3.2 or newer)
- - Boost (1.54 or newer)
+ - Boost (1.55 or newer)
  - OpenSSL
  - [leatherman][leatherman], installed as a standalone library (0.5.1 or newer)
 

--- a/lib/inc/cpp-pcp-client/protocol/v1/serialization.hpp
+++ b/lib/inc/cpp-pcp-client/protocol/v1/serialization.hpp
@@ -5,7 +5,7 @@
 
 #include <leatherman/locale/locale.hpp>
 
-#include <boost/detail/endian.hpp>
+#include <boost/predef/other/endian.h>
 
 #include <string>
 #include <vector>
@@ -27,7 +27,7 @@ typedef std::vector<uint8_t> SerializedMessage;
 // Utility functions
 //
 
-#ifdef BOOST_LITTLE_ENDIAN
+#ifdef BOOST_ENDIAN_LITTLE_BYTE
 
 LIBCPP_PCP_CLIENT_EXPORT uint32_t getNetworkNumber(const uint32_t& number);
 LIBCPP_PCP_CLIENT_EXPORT uint32_t getHostNumber(const uint32_t& number);
@@ -42,7 +42,7 @@ inline uint32_t getHostNumber(const uint32_t& number) {
     return number;
 }
 
-#endif  // BOOST_LITTLE_ENDIAN
+#endif  // BOOST_ENDIAN_LITTLE_BYTE
 
 //
 // Serialize

--- a/lib/src/protocol/v1/serialization.cc
+++ b/lib/src/protocol/v1/serialization.cc
@@ -9,7 +9,7 @@
 namespace PCPClient {
 namespace v1 {
 
-#ifdef BOOST_LITTLE_ENDIAN
+#if BOOST_ENDIAN_LITTLE_BYTE
 
 uint32_t getNetworkNumber(const uint32_t& number)
 {
@@ -21,7 +21,7 @@ uint32_t getHostNumber(const uint32_t& number)
     return ntohl(number);
 }
 
-#endif  // BOOST_LITTLE_ENDIAN
+#endif  // BOOST_ENDIAN_LITTLE_BYTE
 
 }  // namespace v1
 }  // namespace PCPClient


### PR DESCRIPTION
The boost/detail/endian.hpp header is deprecated.

Here is the warning that was coming from the serialization file:

```
In file included from /usr/local/include/cpp-pcp-client/protocol/v1/serialization.hpp:8:
In file included from /usr/local/include/boost/detail/endian.hpp:9:
/usr/local/include/boost/predef/detail/endian_compat.h:11:9: warning: The use of BOOST_*_ENDIAN and BOOST_BYTE_ORDER is deprecated. Please include <boost/predef/other/endian.h> and use BOOST_ENDIAN_*_BYTE instead [-W#pragma-messages]
#pragma message("The use of BOOST_*_ENDIAN and BOOST_BYTE_ORDER is deprecated. Please include <boost/predef/other/endian.h> and use BOOST_ENDIAN_*_BYTE instead")
        ^
1 warning generated.
```