### PR TITLE
(maint) making this build under gcc 7.5.0

### DIFF
--- a/lib/src/connector/connection.cc
+++ b/lib/src/connector/connection.cc
@@ -347,9 +347,11 @@ void Connection::cleanUp()
             break;
 
         case (ConnectionState::open):
-            tryClose();
         case (ConnectionState::closing):
         {
+            if (c_s == ConnectionState::open) {
+                tryClose();
+            }
             lth_util::Timer timer{};
             while (connection_state_.load() == ConnectionState::closing
                    && timer.elapsed_seconds() < 2)


### PR DESCRIPTION
Making this build under gcc (Ubuntu 7.5.0-3ubuntu1~18.04) 7.5.0

    /home/rroland/src/cpp-pcp-client/lib/src/connector/connection.cc: In member function ‘void PCPClient::Connection::cleanUp()’:
    /home/rroland/src/cpp-pcp-client/lib/src/connector/connection.cc:350:21: error: this statement may fall through [-Werror=implicit-fallthrough=]
                 tryClose();
                 ~~~~~~~~^~
    /home/rroland/src/cpp-pcp-client/lib/src/connector/connection.cc:351:9: note: here
             case (ConnectionState::closing):
             ^~~~