### PR TITLE
(maint) if -> ifdef in serialization protocol

### DIFF
--- a/lib/src/protocol/v1/serialization.cc
+++ b/lib/src/protocol/v1/serialization.cc
@@ -9,7 +9,7 @@
 namespace PCPClient {
 namespace v1 {
 
-#if BOOST_ENDIAN_LITTLE_BYTE
+#ifdef BOOST_ENDIAN_LITTLE_BYTE
 
 uint32_t getNetworkNumber(const uint32_t& number)
 {


### PR DESCRIPTION
In a previous commit [1], ifdef was incorrectly changed
to if in the serialization protocol. This commit corrects
that.

[1]: https://github.com/puppetlabs/cpp-pcp-client/commit/36ec2eba1ee6c0edeaaaaad9836041f84a02e463#diff-03a0c044596526965eba33d65a5657dbR12