### PR TITLE
(PE-33165) Disable websocket logging

### DIFF
--- a/lib/inc/cpp-pcp-client/connector/connection.hpp
+++ b/lib/inc/cpp-pcp-client/connector/connection.hpp
@@ -29,6 +29,10 @@ namespace websocketpp {
     template <typename T>
     class client;
 
+     namespace config {
+         struct asio_tls_client;
+     }
+
     namespace message_buffer {
         namespace alloc {
             template <typename message>
@@ -58,7 +62,9 @@ static const std::string DEFAULT_CLOSE_REASON { "Closed by client" };
 
 // Configuration of the WebSocket transport layer
 
-using WS_Client_Type = websocketpp::client<ws_config>;
+// Use the default client type, without devel logging enabled, until PE-33165
+// is fixed.
+using WS_Client_Type = websocketpp::client<websocketpp::config::asio_tls_client>;
 using WS_Context_Ptr = websocketpp::lib::shared_ptr<boost::asio::ssl::context>;
 using WS_Connection_Handle = websocketpp::connection_hdl;
 

--- a/lib/src/connector/connection.cc
+++ b/lib/src/connector/connection.cc
@@ -85,10 +85,12 @@ Connection::Connection(std::vector<std::string> broker_ws_uris,
           consecutive_pong_timeouts_ { 0 },
           endpoint_ { new WS_Client_Type() }
 {
+    // Disable websocket logging until PE-33165 is resolved.
+    setWebSocketLogLevel(leatherman::logging::log_level::none);
+    setWebSocketLogStream(nullptr);
+
     // Initialize the transport system. Note that in perpetual mode,
     // the event loop does not terminate when there are no connections
-    setWebSocketLogLevel(client_metadata_.loglevel);
-    setWebSocketLogStream(client_metadata_.logstream);
     endpoint_->init_asio();
     endpoint_->start_perpetual();
 


### PR DESCRIPTION
There is an undiagnosed bug around websocket logging on Windows, so
temporarily disable that logging until a solution can be found.

This restores the use of the default ASIO TLS client config, rather than
our custom config which enables devel logging. It also explicitly sets
the websocket log level to none and doesn't set a stream.