### PR TITLE
Get tutorial building on macOS

### DIFF
--- a/tutorial/README.md
+++ b/tutorial/README.md
@@ -7,8 +7,10 @@ cpp-pcp-client.
 
 To build on OS X:
 ```
-    g++ -std=c++11 -o agent -L /usr/local/lib -lcpp-pcp-client \
-    -lboost_system -I ../../../lib/inc main.cpp
+    export CPLUS_INCLUDE_PATH=/opt/homebrew/Cellar/boost/1.83.0/include
+    g++ -std=c++11 -o agent -Wl,-rpath,/usr/local/lib -L/opt/homebrew/lib \
+      -lcpp-pcp-client -lboost_system -I ../../../lib/inc \
+      main.cpp
 ```
 
 You need to install PCP and [leatherman][1] before that: `make` then


### PR DESCRIPTION
When building this locally, I had to set this CPLUS_INCLUDE_PATH in order to get past a compile error on the tutorial steps. I also had to add /opt/homebrewlib and the rpath to get the tutorial to build and run.